### PR TITLE
Refactor the command-line interface using Click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "requests",
     "natsort",
     "vcfpy",
-    "pybedtools"
+    "pybedtools",
+    "click"
 ]
 
 [project.scripts]

--- a/sftool/cli.py
+++ b/sftool/cli.py
@@ -19,107 +19,25 @@ Esta herramienta permite a los usuarios analizar archivos VCF para el manejo aut
 @github https://github.com/babelomics/SFtool
 """
 
-import sys
-import pickle
-from pathlib import Path
+import click
 
-from sftool.utils.errors import (
-    BootstrapError
+from sftool.commands.run import run
+from sftool.commands.check import check
+
+
+@click.group(
+    context_settings={"help_option_names": ["-h", "--help"]}
 )
-
-from sftool.utils.arguments import parse_arguments
-from sftool.core.bootstrap import bootstrap_execution
-from sftool.steps.catalog_generation import run as run_catalog_generation
-from sftool.steps.clinvar_setup import run as run_clinvar_setup
-from sftool.steps.sample_preprocessing import run as run_sample_preprocessing
-from sftool.steps.variant_evidence_preparation import run as run_variant_evidence_preparation
-from sftool.steps.variant_collection import run as run_variant_collection
-from sftool.steps.variant_selection import run as run_variant_selection
-from sftool.steps.report_generation import run as run_report_generation
-
-
+@click.version_option()
 def main():
-
-    # --------------------------
-    # Parse CLI arguments
-    # --------------------------
-    args = parse_arguments()
-    outdir = args.outdir
-
-    if not args.debug_load_ctx:
-
-        # ----------------------------
-        # STEP 1: SFtool bootstraping: JSON inputs validation, create execution context object and validate run dependencies
-        # ----------------------------
-
-        try:
-            ctx = bootstrap_execution(args.samples, args.config, outdir)
-        except BootstrapError as e:
-            print(f"[ERROR] {e}")
-            sys.exit(1)
-
-        # ----------------------------
-        # STEP 2: JSON and BED files catalog generation
-        # ----------------------------
-        run_catalog_generation(ctx)
-
-        # ----------------------------
-        # STEP 3: CLINVAR DDBB MANAGEMENT
-        #           Only if 'clinvar' is present in variant_classification_sources
-        # ----------------------------
-        variant_classification_sources = ctx.variant_classification_sources
-        # Get unique list of categories for all samples
-        categories = sorted({
-            c for s in ctx.samples for c in s.categories
-        })
-
-        if 'clinvar' in variant_classification_sources and ("PR" in categories or "RR" in categories):
-            run_clinvar_setup(ctx)
+    """
+    SFtool: manage personal, reproductive and pharmacogenomic secondary findings.
+    """
+    pass
 
 
-        # ----------------------------
-        # STEP 4: SAMPLE PREPROCESSING
-        #
-        # ----------------------------
-        run_sample_preprocessing(ctx)
-
-
-        # ----------------------------
-        # STEP 5: VARIANT EVIDENCE PREPARATION (GENEBE AND/OR CLINVAR)
-        #
-        # ----------------------------
-        run_variant_evidence_preparation(ctx)
-
-
-
-        # ----------------------------
-        # STEP 6: VARIANT COLLECTION (GENEBE AND/OR CLINVAR, STRs and SMN1-copy, pharmCAT)
-        #
-        # ----------------------------
-        run_variant_collection(ctx)
-
-
-        # ----------------------------
-        # STEP 7: VARIANT SELECTION from the set of VARIANT COLLECTION
-        #
-        # ----------------------------
-        run_variant_selection(ctx)
-
-        if args.debug_dump_ctx:
-            debug_ctx_path = Path(outdir) / "ctx_backup_rr_screening_CFTR.pkl"
-            with open(debug_ctx_path, 'wb') as f:
-                pickle.dump(ctx, f)
-
-    else:
-        debug_ctx_path = Path(outdir) / "ctx_backup_rr_screening_CFTR.pkl"
-        with open(debug_ctx_path, "rb") as f:
-            ctx = pickle.load(f)
-        # ----------------------------
-        # STEP 6: REPORT GENERATION
-        #
-        # ----------------------------
-        run_report_generation(ctx)
-
+main.add_command(run)
+main.add_command(check)
 
 if __name__ == "__main__":
     main()

--- a/sftool/cli.py
+++ b/sftool/cli.py
@@ -1,39 +1,34 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
-"""
-Herramienta para el manejo automático de hallazgos secundarios.
-
-Esta herramienta permite a los usuarios analizar archivos VCF para el manejo automático de hallazgos secundarios relacionados con riesgo personal, riesgo reproductivo y farmacogenético.
-
-
-@Usage python3.10 -m sftool.cli
-    --samples <samples_info.json>
-    --config <config_info.json>
-     --outdir <root_output_dir>
-     --force
-
-@Author Javier Perez FLorido, Edurne Urrutia Lafuente
-@Date 2023/08/01
-@email javier.perez.florido.sspa@juntadeandalucia.es, edurlaf@gmail.com
-@github https://github.com/babelomics/SFtool
-"""
-
 import click
 
 from sftool.commands.run import run
 from sftool.commands.check import check
 
+CONTEXT_SETTINGS = {
+    "help_option_names": ["-h", "--help"]
+}
 
 @click.group(
-    context_settings={"help_option_names": ["-h", "--help"]}
+    context_settings=CONTEXT_SETTINGS,
+    invoke_without_command=True
 )
 @click.version_option()
-def main():
+@click.pass_context
+
+def main(ctx):
     """
     SFtool: manage personal, reproductive and pharmacogenomic secondary findings.
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.secho("Error: no command specified.\n", fg="red", bold=True)
+        click.echo("Available commands:")
+        click.echo("  run     Execute the complete SFtool workflow.")
+        click.echo("  check   Validate the execution environment and configuration.")
+        click.echo()
+        click.echo("Run 'sftool --help' for more information.")
+        ctx.exit(1)
 
 
 main.add_command(run)

--- a/sftool/commands/check.py
+++ b/sftool/commands/check.py
@@ -1,0 +1,28 @@
+import click
+
+
+@click.command(
+    help=(
+            "Check whether SFtool inputs, configuration files and external "
+            "dependencies are correctly available."
+    )
+)
+@click.option(
+    "--config",
+    "config_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to the SFtool configuration JSON file."
+)
+@click.option(
+    "--samples",
+    "samples_path",
+    required=False,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Optional samples_info JSON file to validate sample-specific inputs."
+)
+def check(config_path, samples_path):
+    """
+    Check SFtool environment and input files.
+    """
+    # TO BE DONE

--- a/sftool/commands/check.py
+++ b/sftool/commands/check.py
@@ -1,25 +1,32 @@
 import click
 
 
+CHECK_HELP = """
+Validate the SFtool execution environment and configuration.
+
+\b
+Examples:
+  sftool check --config config.json 
+
+  sftool check --config config.json --samples samples_info.json
+"""
+
 @click.command(
-    help=(
-            "Check whether SFtool inputs, configuration files and external "
-            "dependencies are correctly available."
-    )
+    help=CHECK_HELP
 )
 @click.option(
     "--config",
     "config_path",
     required=True,
     type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="Path to the SFtool configuration JSON file."
+    help="Path to the SFtool configuration JSON file (see template in examples/config.schema.json)."
 )
 @click.option(
     "--samples",
     "samples_path",
     required=False,
     type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="Optional samples_info JSON file to validate sample-specific inputs."
+    help="Optional samples_info JSON file to validate sample-specific inputs (see template in examples/samples_info.schema.json)."
 )
 def check(config_path, samples_path):
     """

--- a/sftool/commands/run.py
+++ b/sftool/commands/run.py
@@ -1,0 +1,141 @@
+import click
+import sys
+import pickle
+from pathlib import Path
+
+from sftool.utils.errors import (
+    BootstrapError
+)
+
+from sftool.core.bootstrap import bootstrap_execution
+from sftool.steps.catalog_generation import run as run_catalog_generation
+from sftool.steps.clinvar_setup import run as run_clinvar_setup
+from sftool.steps.sample_preprocessing import run as run_sample_preprocessing
+from sftool.steps.variant_evidence_preparation import run as run_variant_evidence_preparation
+from sftool.steps.variant_collection import run as run_variant_collection
+from sftool.steps.variant_selection import run as run_variant_selection
+from sftool.steps.report_generation import run as run_report_generation
+
+
+@click.command(
+    help=(
+            "Run the complete SFtool workflow using a samples_info JSON file "
+            "and a configuration JSON file."
+    )
+)
+@click.option(
+    "--samples",
+    "samples_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to the samples_info JSON file."
+)
+@click.option(
+    "--config",
+    "config_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to the SFtool configuration JSON file."
+)
+@click.option(
+    "--outdir",
+    required=True,
+    type=click.Path(file_okay=False, writable=True),
+    help="Directory where SFtool output will be written."
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite or reuse an existing output directory when applicable."
+)
+@click.option(
+    "--debug-dump-ctx",
+    is_flag=True,
+    hidden=True,
+    help="Dump the internal ExecutionContext object for debugging."
+)
+@click.option(
+    "--debug-load-ctx",
+    is_flag=True,
+    hidden=True,
+    help="Load a previously dumped ExecutionContext object for debugging."
+)
+
+def run(samples_path, config_path, outdir, force, debug_dump_ctx, debug_load_ctx):
+    """
+    Run SFtool analysis.
+    """
+
+    if not debug_load_ctx:
+
+        # ----------------------------
+        # STEP 1: SFtool bootstraping: JSON inputs validation, create execution context object and validate run dependencies
+        # ----------------------------
+
+        try:
+            ctx = bootstrap_execution(samples_path, config_path, outdir)
+        except BootstrapError as e:
+            print(f"[ERROR] {e}")
+            sys.exit(1)
+
+        # ----------------------------
+        # STEP 2: JSON and BED files catalog generation
+        # ----------------------------
+        run_catalog_generation(ctx)
+
+        # ----------------------------
+        # STEP 3: CLINVAR DDBB MANAGEMENT
+        #           Only if 'clinvar' is present in variant_classification_sources
+        # ----------------------------
+        variant_classification_sources = ctx.variant_classification_sources
+        # Get unique list of categories for all samples
+        categories = sorted({
+            c for s in ctx.samples for c in s.categories
+        })
+
+        if 'clinvar' in variant_classification_sources and ("PR" in categories or "RR" in categories):
+            run_clinvar_setup(ctx)
+
+
+        # ----------------------------
+        # STEP 4: SAMPLE PREPROCESSING
+        #
+        # ----------------------------
+        run_sample_preprocessing(ctx)
+
+
+        # ----------------------------
+        # STEP 5: VARIANT EVIDENCE PREPARATION (GENEBE AND/OR CLINVAR)
+        #
+        # ----------------------------
+        run_variant_evidence_preparation(ctx)
+
+
+
+        # ----------------------------
+        # STEP 6: VARIANT COLLECTION (GENEBE AND/OR CLINVAR, STRs and SMN1-copy, pharmCAT)
+        #
+        # ----------------------------
+        run_variant_collection(ctx)
+
+
+        # ----------------------------
+        # STEP 7: VARIANT SELECTION from the set of VARIANT COLLECTION
+        #
+        # ----------------------------
+        run_variant_selection(ctx)
+
+        if debug_dump_ctx:
+            debug_ctx_path = Path(outdir) / "ctx_backup_rr_screening_CFTR.pkl"
+            with open(debug_ctx_path, 'wb') as f:
+                pickle.dump(ctx, f)
+
+    else:
+        debug_ctx_path = Path(outdir) / "ctx_backup_rr_screening_CFTR.pkl"
+        with open(debug_ctx_path, "rb") as f:
+            ctx = pickle.load(f)
+        # ----------------------------
+        # STEP 6: REPORT GENERATION
+        #
+        # ----------------------------
+        run_report_generation(ctx)

--- a/sftool/commands/run.py
+++ b/sftool/commands/run.py
@@ -17,25 +17,34 @@ from sftool.steps.variant_selection import run as run_variant_selection
 from sftool.steps.report_generation import run as run_report_generation
 
 
+RUN_HELP = """
+Run the complete SFtool workflow.
+
+\b
+Example:
+  sftool run \\
+    --samples samples_info.json \\
+    --config config.json \\
+    --outdir results \\
+    --force
+"""
+
 @click.command(
-    help=(
-            "Run the complete SFtool workflow using a samples_info JSON file "
-            "and a configuration JSON file."
-    )
+    help=RUN_HELP
 )
 @click.option(
     "--samples",
     "samples_path",
     required=True,
     type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="Path to the samples_info JSON file."
+    help="Path to the samples_info JSON file (see template in examples/samples_info.schema.json)."
 )
 @click.option(
     "--config",
     "config_path",
     required=True,
     type=click.Path(exists=True, dir_okay=False, readable=True),
-    help="Path to the SFtool configuration JSON file."
+    help="Path to the SFtool configuration JSON file (see template in examples/config.schema.json)."
 )
 @click.option(
     "--outdir",


### PR DESCRIPTION
## Summary
This PR replaces the previous `argparse`-based command-line interface with a modern CLI built on the Click framework.

The refactoring improves the usability and extensibility of SFtool while preserving the existing execution workflow. The new CLI architecture has been designed to support additional subcommands in the future, with the implementation of `sftool check` planned in a separate issue.


## Related Issue
Closes #44 

## Type of change
- [ ] Feature (feat)
- [ ] Bug fix (fix)
- [X] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Tests
- [ ] Maintenance / Chore

## Checklist
- [X] Code compiles and runs
- [ ] Tests added or updated
- [ ] Documentation updated
- [X] Linked the related issue (e.g., "Closes #44 ")
