### PR TITLE
Implement the sftool check command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist/
 sftool.sif
 temp
 final_output
+.sftool_check_tmp

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ sftool.sif
 temp
 final_output
 .sftool_check_tmp
+GeneBe client.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ dependencies = [
     "natsort",
     "vcfpy",
     "pybedtools",
-    "click"
+    "click",
+    "packaging"
 ]
 
 [project.scripts]
@@ -55,4 +56,5 @@ sftool = "sftool.cli:main"
 include = ["sftool*"]
 
 [tool.setuptools.package-data]
+"sftool.data" = ["runtime_requirements.toml"]
 "sftool.data.categories" = ["*"]

--- a/sftool/commands/check.py
+++ b/sftool/commands/check.py
@@ -106,8 +106,13 @@ def check(config_path, samples_path):
         config = Config(config_data)
         _ok("Config object created")
 
-        check_runtime_dependencies(config.paths)
-        _ok("Runtime dependencies are available")
+        # Check versions
+        versions = check_runtime_dependencies(config.paths)
+        for tool in versions.values():
+            _ok(
+                f"{tool.name}: {tool.version} "
+                f"(minimum {tool.minimum})"
+            )
 
         if samples_info:
             check_output_dir = Path.cwd() / ".sftool_check_tmp"

--- a/sftool/commands/check.py
+++ b/sftool/commands/check.py
@@ -1,4 +1,45 @@
+from pathlib import Path
+from sftool.core.bootstrap import (
+    load_json,
+    validate_samples_info,
+    validate_config,
+    validate_execution_context,
+)
+from sftool.core.config import Config
+from sftool.core.context import ExecutionContext, SampleContext
+from sftool.utils.errors import RuntimeDependencyError, ValidationError
+from sftool.utils.runtime import check_runtime_dependencies
 import click
+
+
+def _ok(message: str):
+    click.secho(f"✓ {message}", fg="green")
+
+
+def _fail(message: str):
+    click.secho(f"✗ {message}", fg="red")
+
+
+def _warn(message: str):
+    click.secho(f"⚠ {message}", fg="yellow")
+
+
+def _build_context_for_check(
+        samples_info: dict,
+        config: Config,
+        output_dir: Path,
+) -> ExecutionContext:
+    ctx = ExecutionContext(
+        execution_meta=samples_info["execution"],
+        config=config,
+        output_dir=output_dir,
+    )
+
+    for sample_data in samples_info["samples"]:
+        sample_ctx = SampleContext(sample_data=sample_data, exec_ctx=ctx)
+        ctx.add_sample(sample_ctx)
+
+    return ctx
 
 
 CHECK_HELP = """
@@ -30,6 +71,68 @@ Examples:
 )
 def check(config_path, samples_path):
     """
-    Check SFtool environment and input files.
+    Check SFtool environment and input files without running the workflow
     """
-    # TO BE DONE
+    click.echo()
+    click.secho("SFtool environment check", bold=True)
+    click.echo()
+
+    try:
+        config_path = Path(config_path)
+        config_data = load_json(config_path)
+        _ok(f"Config JSON loaded: {config_path}")
+
+        samples_info = None
+
+        if samples_path:
+            samples_path = Path(samples_path)
+            samples_info = load_json(samples_path)
+            _ok(f"Samples JSON loaded: {samples_path}")
+
+            validate_samples_info(samples_info)
+            _ok("samples_info structure is valid")
+
+            validate_config(config_data, samples_info)
+            _ok("config structure is valid for requested categories")
+        else:
+            validate_config(config_data)
+            _ok("config structure is valid")
+
+            _warn(
+                "No samples file provided. Sample-specific checks and "
+                "category-dependent checks will be skipped."
+            )
+
+        config = Config(config_data)
+        _ok("Config object created")
+
+        check_runtime_dependencies(config.paths)
+        _ok("Runtime dependencies are available")
+
+        if samples_info:
+            check_output_dir = Path.cwd() / ".sftool_check_tmp"
+
+            ctx = _build_context_for_check(
+                samples_info=samples_info,
+                config=config,
+                output_dir=check_output_dir,
+            )
+
+            validate_execution_context(ctx)
+            _ok("Execution context is valid")
+
+        click.echo()
+        click.secho("SFtool check completed successfully.", fg="green", bold=True)
+
+    except (
+            ValidationError,
+            RuntimeDependencyError,
+            FileNotFoundError,
+            ValueError,
+            KeyError,
+    ) as e:
+        click.echo()
+        _fail(str(e))
+        click.echo()
+        click.secho("SFtool check failed.", fg="red", bold=True)
+        raise click.Abort()

--- a/sftool/core/bootstrap.py
+++ b/sftool/core/bootstrap.py
@@ -286,7 +286,7 @@ def validate_sample_block(samples: Dict[str, Any], mode):
 
 
 
-def validate_config(config: Dict[str, Any], samples_info: dict):
+def validate_config(config: Dict[str, Any], samples_info: dict | None = None):
     required = [
         "paths", "references", "catalogs",
         "clinvar", "genebe_credentials", "smaca_thresholds"
@@ -332,11 +332,15 @@ def validate_config(config: Dict[str, Any], samples_info: dict):
     # ----------------------------------------------------
     # Validate pharmCAT_positions_vcf file existence when PGx category exists
     # ----------------------------------------------------
-    requested_categories = {
-        category
-        for sample in samples_info["samples"]
-        for category in sample.get("categories", [])
-    }
+
+    requested_categories = set()
+
+    if samples_info is not None:
+        requested_categories = {
+            category
+            for sample in samples_info["samples"]
+            for category in sample.get("categories", [])
+        }
 
     if "PGx" in requested_categories:
         if "pharmCAT_positions_vcf" not in references:
@@ -348,9 +352,6 @@ def validate_config(config: Dict[str, Any], samples_info: dict):
             raise ValidationError(
                 f"pharmCAT_positions_vcf does not exist: {pharmCAT_positions}"
             )
-
-
-
 
     # ----------------------------------------------------
     # Validate catalogs (PR, RR, STR, PGx) file existence

--- a/sftool/core/bootstrap.py
+++ b/sftool/core/bootstrap.py
@@ -41,11 +41,11 @@ def bootstrap_execution(
     output_dir = Path(output_dir)
     tmp_dir = Path(tmp_dir) if tmp_dir else None
 
-    _validate_file_exists(samples_json, "samples_info JSON")
-    _validate_file_exists(config_json, "config JSON")
+    validate_file_exists(samples_json, "samples_info JSON")
+    validate_file_exists(config_json, "config JSON")
 
-    samples_info = _load_json(samples_json)
-    config_data = _load_json(config_json)
+    samples_info = load_json(samples_json)
+    config_data = load_json(config_json)
 
     # -----------------------------------------------------------------
     # Legacy-equivalent validations (dict-level)
@@ -88,7 +88,7 @@ def bootstrap_execution(
 # JSON utilities
 # =====================================================================
 
-def _load_json(path: Path) -> Dict[str, Any]:
+def load_json(path: Path) -> Dict[str, Any]:
     try:
         with path.open() as fh:
             return json.load(fh)
@@ -96,7 +96,7 @@ def _load_json(path: Path) -> Dict[str, Any]:
         raise ValueError(f"Invalid JSON in {path}: {e}") from e
 
 
-def _validate_file_exists(path: Path, label: str):
+def validate_file_exists(path: Path, label: str):
     if not path.exists():
         raise FileNotFoundError(f"{label} not found: {path}")
     if not path.is_file():

--- a/sftool/data/runtime_requirements.toml
+++ b/sftool/data/runtime_requirements.toml
@@ -1,0 +1,17 @@
+[python]
+minimum = "3.12"
+
+[java]
+minimum = "21.0.0"
+
+[bcftools]
+minimum = "1.21"
+
+[bgzip]
+minimum = "1.21"
+
+[genebe]
+minimum = "0.1.0-a.22"
+
+[pharmcat]
+minimum = "3.2.0"

--- a/sftool/report/sample_tables.py
+++ b/sftool/report/sample_tables.py
@@ -1,7 +1,7 @@
-from sftool.report.models import ReportTable
 import os
-import subprocess
-import re
+
+from sftool.report.models import ReportTable
+from sftool.utils.runtime import get_runtime_versions
 
 
 def build_sample_tables(ctx, sample):
@@ -25,40 +25,6 @@ def build_sample_tables(ctx, sample):
 # Versions and paths
 def _build_versions_and_paths_table(ctx, sample):
 
-    try:
-        cmd = [ctx.config.paths.java,
-               "-jar",
-               ctx.config.paths.genebe,
-               "version"
-               ]
-
-        # Run command and get output
-        genebe_process = subprocess.Popen(cmd, stdout = subprocess.PIPE)
-        genebe_out, genebe_err = genebe_process.communicate()
-
-    except subprocess.CalledProcessError as e:
-        print(f"Error running GeneBe: {e.output}")
-
-
-    # Bcftools version
-    try:
-        cmd = [ctx.config.paths.bcftools, "--version"]
-
-        bcftools_process = subprocess.Popen(cmd, stdout= subprocess.PIPE)
-        bcftools_out, bcftools_err = bcftools_process.communicate()
-
-    except subprocess.CalledProcessError as e:
-        print(f"Error running bcftools: {e.output}")
-
-    # PharmCAT version
-    try:
-        pharmCAT_command = [ctx.config.paths.java, "-jar", ctx.config.paths.pharmCAT , "-version"]
-        pharmCAT_process = subprocess.Popen(pharmCAT_command, stdout = subprocess.PIPE)
-        pharmCAT_output, pharmCAT_err = pharmCAT_process.communicate()
-
-    except subprocess.CalledProcessError as e:
-        print(f"Error running pharmCAT: {e.output}")
-
     category_string = ''
     for category in sample.categories:
         if category == 'PR':
@@ -71,6 +37,7 @@ def _build_versions_and_paths_table(ctx, sample):
     category_string = category_string.rstrip(", ")
     variant_classification_sources_string = ", ".join(ctx.variant_classification_sources)
 
+    versions = get_runtime_versions(ctx.config.paths)
 
     rows = [
         {"Field": "SF tool version", "Value": ctx.config.version},
@@ -95,10 +62,10 @@ def _build_versions_and_paths_table(ctx, sample):
         {"Field": "Clinvar version", "Value": ctx.config.clinvar.version if 'clinvar' in ctx.variant_classification_sources else "Not used"},
         {"Field": "Clinvar path", "Value": ctx.config.clinvar.db_path if 'clinvar' in ctx.variant_classification_sources else "Not used"},
         {"Field": "Clinvar evidence level", "Value": str(ctx.clinvar_evidence) if 'clinvar' in ctx.variant_classification_sources else "Not used"},
-        {"Field": "GeneBe version", "Value": "Not used" if ("PR" not in sample.categories and "rr" not in sample.categories) else re.search(r'version:\s*(.*?)\s*::', str(genebe_out)).group(1)},
+        {"Field": "GeneBe version", "Value": "Not used" if ("PR" not in sample.categories and "rr" not in sample.categories) else versions["genebe"].version},
         {"Field": "GeneBe path", "Value": ctx.config.paths.genebe},
-        {"Field": "bcftools version", "Value": str(bcftools_out).split(" ")[1].split("\\n")[0]},
-        {"Field": "pharmCAT version", "Value": pharmCAT_output.decode().strip() if 'PGx' in sample.categories else "Not used"},
+        {"Field": "bcftools version", "Value": versions["bcftools"].version},
+        {"Field": "pharmCAT version", "Value": versions["pharmcat"].version if 'PGx' in sample.categories else "Not used"},
         {"Field": "HPO genes to phenotype version", "Value": os.path.splitext(os.path.basename(ctx.config.references.gene_to_phenotype_file))[0].split("_")[-1]},
         {"Field": "HPO genes to phenotype path", "Value": ctx.config.references.gene_to_phenotype_file}
     ]

--- a/sftool/utils/runtime.py
+++ b/sftool/utils/runtime.py
@@ -6,8 +6,57 @@ required external tools and resources exist before execution.
 """
 
 import os
+import re
+import subprocess
+from dataclasses import dataclass
+from packaging.version import Version, InvalidVersion
 from sftool.utils.errors import RuntimeDependencyError
 from sftool.core.config import PathsConfig
+from importlib.resources import files
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+
+@dataclass
+class ToolVersion:
+    name: str
+    path: str
+    version: str
+    minimum: str
+    ok: bool
+
+
+
+def load_runtime_requirements() -> dict[str, str]:
+    requirements_file = files("sftool.data") / "runtime_requirements.toml"
+
+    with requirements_file.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    return {
+        tool: values["minimum"]
+        for tool, values in data.items()
+    }
+
+
+def run_command(cmd: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            cmd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return (result.stdout or result.stderr).strip()
+    except subprocess.CalledProcessError as e:
+        raise RuntimeDependencyError(
+            f"Command failed: {' '.join(map(str, cmd))}\n{e.stderr or e.stdout}"
+        ) from e
+
 
 
 # =====================================================
@@ -38,14 +87,155 @@ def check_executable(label, path):
             f"{label} exists but is NOT executable: {path}"
         )
 
+def normalize_version(version: str) -> str:
+    """
+    Normalize non-standard version strings before comparison.
 
+    Example:
+    0.1.0-a.22 -> 0.1.0a22
+    """
+    return (
+        version.strip()
+        .replace("-a.", "a")
+        .replace("-a", "a")
+    )
+
+def is_version_supported(version: str, minimum: str) -> bool:
+    return Version(normalize_version(version)) >= Version(normalize_version(minimum))
+
+def inspect_tool(name: str, path: str, version: str, minimum: str) -> ToolVersion:
+    return ToolVersion(
+        name=name,
+        path=path,
+        version=version,
+        minimum=minimum,
+        ok=is_version_supported(version, minimum),
+    )
+
+def get_python_version(python_path: str) -> str:
+    output = run_command([python_path, "--version"])
+    match = re.search(r"Python\s+([\d.]+)", output)
+    if not match:
+        raise RuntimeDependencyError(f"Could not parse Python version from: {output}")
+    return match.group(1)
+
+
+def get_java_version(java_path: str) -> str:
+    output = run_command([java_path, "-version"])
+
+    # openjdk version "21.0.2" 2024-01-16
+    # java version "21.0.0" ...
+    match = re.search(r'version\s+"([^"]+)"', output)
+    if not match:
+        raise RuntimeDependencyError(f"Could not parse Java version from: {output}")
+
+    return match.group(1)
+
+
+def get_bcftools_version(bcftools_path: str) -> str:
+    output = run_command([bcftools_path, "--version"])
+
+    # bcftools 1.21
+    match = re.search(r"bcftools\s+([\w.\-]+)", output)
+    if not match:
+        raise RuntimeDependencyError(f"Could not parse bcftools version from: {output}")
+
+    return match.group(1)
+
+
+def get_bgzip_version(bgzip_path: str) -> str:
+    output = run_command([bgzip_path, "--version"])
+
+    # bgzip (htslib) 1.21
+    # or bgzip 1.21
+    match = re.search(r"(?:bgzip\s+\(htslib\)\s+|bgzip\s+)([\w.\-]+)", output)
+    if not match:
+        raise RuntimeDependencyError(f"Could not parse bgzip version from: {output}")
+
+    return match.group(1)
+
+
+def get_genebe_version(java_path: str, genebe_path: str) -> str:
+    output = run_command([
+        java_path,
+        "-jar",
+        genebe_path,
+        "version",
+    ])
+
+    # current parsing in sample_tables.py expects:
+    # version: ... ::
+    match = re.search(r"version:\s*(.*?)\s*::", output)
+    if not match:
+        raise RuntimeDependencyError(f"Could not parse GeneBe version from: {output}")
+
+    return match.group(1)
+
+
+def get_pharmcat_version(java_path: str, pharmcat_path: str) -> str:
+    output = run_command([
+        java_path,
+        "-jar",
+        pharmcat_path,
+        "-version",
+    ])
+
+    # PharmCAT often returns something like "PharmCAT 3.2.0" or just "3.2.0"
+    match = re.search(r"(\d+\.\d+\.\d+)", output)
+    if not match:
+        raise RuntimeDependencyError(f"Could not parse PharmCAT version from: {output}")
+
+    return match.group(1)
+
+
+def get_runtime_versions(paths_cfg: PathsConfig) -> dict[str, ToolVersion]:
+    requirements = load_runtime_requirements()
+
+    return {
+        "python": inspect_tool(
+            "python",
+            paths_cfg.python,
+            get_python_version(paths_cfg.python),
+            requirements["python"],
+        ),
+        "java": inspect_tool(
+            "java",
+            paths_cfg.java,
+            get_java_version(paths_cfg.java),
+            requirements["java"],
+        ),
+        "bcftools": inspect_tool(
+            "bcftools",
+            paths_cfg.bcftools,
+            get_bcftools_version(paths_cfg.bcftools),
+            requirements["bcftools"],
+        ),
+        "bgzip": inspect_tool(
+            "bgzip",
+            paths_cfg.bgzip,
+            get_bgzip_version(paths_cfg.bgzip),
+            requirements["bgzip"],
+        ),
+        "genebe": inspect_tool(
+            "genebe",
+            paths_cfg.genebe,
+            get_genebe_version(paths_cfg.java, paths_cfg.genebe),
+            requirements["genebe"],
+        ),
+        "pharmcat": inspect_tool(
+            "pharmcat",
+            paths_cfg.pharmCAT,
+            get_pharmcat_version(paths_cfg.java, paths_cfg.pharmCAT),
+            requirements["pharmcat"],
+        ),
+    }
 # =====================================================
 # Runtime dependency checking
 # =====================================================
 
 def check_runtime_dependencies(paths_cfg: PathsConfig):
     """
-    Check that required runtime dependencies exist.
+    Check that required runtime dependencies exist, are executable and their versions.
 
     This function preserves the semantics of the legacy runtime.py
     and only adapts the input interface to PathsConfig.
@@ -65,3 +255,26 @@ def check_runtime_dependencies(paths_cfg: PathsConfig):
     check_file_exists("GeneBe JAR file", paths_cfg.genebe)
     check_file_exists("PharmCAT JAR file", paths_cfg.pharmCAT)
 
+    # --------------------------------------------------------------
+    # Version checks
+    # --------------------------------------------------------------
+    versions = get_runtime_versions(paths_cfg)
+
+    failed = [
+        tool
+        for tool in versions.values()
+        if not tool.ok
+    ]
+
+    if failed:
+        details = "\n".join(
+            f"- {tool.name}: found {tool.version}, required >= {tool.minimum}"
+            for tool in failed
+        )
+
+        raise RuntimeDependencyError(
+            "Unsupported runtime dependency versions:\n"
+            f"{details}"
+        )
+
+    return versions


### PR DESCRIPTION
## Summary
This PR introduces the new `sftool check` command, providing a comprehensive validation of the SFtool execution environment without running the analysis workflow.

The command verifies the software environment, configuration files and (optionally) sample inputs by reusing the existing validation framework already implemented in the `core` package. It also validates the versions of all required third-party dependencies against the minimum supported versions defined by SFtool.


## Related Issue
Closes #46 

## Type of change
- [X] Feature (feat)
- [ ] Bug fix (fix)
- [X] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Tests
- [ ] Maintenance / Chore

## Checklist
- [X] Code compiles and runs
- [ ] Tests added or updated
- [ ] Documentation updated
- [X] Linked the related issue (e.g., "Closes #46")
