### PR TITLE
 Variant Confirmation workflow: Phase 6 - Report generation

### DIFF
--- a/sftool/report/sample_tables.py
+++ b/sftool/report/sample_tables.py
@@ -2,6 +2,7 @@ import os
 
 from sftool.report.models import ReportTable
 from sftool.utils.runtime import get_runtime_versions
+from sftool.report.variant_confirmation_table import build_variant_confirmation_table
 
 
 def build_sample_tables(ctx, sample):
@@ -9,6 +10,7 @@ def build_sample_tables(ctx, sample):
 
     tables = [
         _build_versions_and_paths_table(ctx, sample),
+        build_variant_confirmation_table(ctx, sample),
         _build_pr_rr_snv_indels_table(selected_variants, "PR"),
         _build_pr_rr_snv_indels_table(selected_variants, "RR"),
         _build_rr_str_table(selected_variants),

--- a/sftool/report/variant_confirmation_table.py
+++ b/sftool/report/variant_confirmation_table.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
+
+from sftool.report.models import ReportTable
+from sftool.variant_confirmation.models import (
+    VariantCandidate,
+    VariantConfirmationResult,
+    VariantMatch,
+)
+
+
+TAB_NAME = "Variant confirmation"
+NOT_AVAILABLE = "NA"
+
+
+def build_variant_confirmation_table(ctx, sample) -> Optional[ReportTable]:
+    """
+    Build the per-sample Variant Confirmation report table.
+
+    One row is generated for every candidate/GeneBe annotation combination.
+    Candidates without GeneBe annotations still generate one row so that
+    negative and unannotated results remain visible in the report.
+    """
+    result = sample.results.get("variant_confirmation")
+
+    if result is None:
+        return None
+
+    if not isinstance(result, VariantConfirmationResult):
+        raise TypeError(
+            "sample.results['variant_confirmation'] must be a "
+            "VariantConfirmationResult"
+        )
+
+    gene_hpos = _load_gene_hpos(
+        ctx.config.references.gene_to_phenotype_file
+    )
+    sample_hpos = set(sample.hpo_terms or [])
+
+    rows: List[Dict[str, Any]] = []
+
+    for candidate in result.candidates:
+        variant_match = result.get_match(candidate.candidate_id)
+
+        if variant_match is None:
+            raise ValueError(
+                "Variant Confirmation result is incomplete: no match found "
+                f"for candidate {candidate.candidate_id!r}"
+            )
+
+        annotations = variant_match.annotations or [None]
+
+        for annotation in annotations:
+            rows.append(
+                _build_report_row(
+                    result=result,
+                    candidate=candidate,
+                    variant_match=variant_match,
+                    annotation=annotation,
+                    gene_hpos=gene_hpos,
+                    sample_hpos=sample_hpos,
+                )
+            )
+
+    if not rows:
+        return None
+
+    return ReportTable(
+        tab_name=TAB_NAME,
+        rows=rows,
+    )
+
+
+def _build_report_row(
+        result: VariantConfirmationResult,
+        candidate: VariantCandidate,
+        variant_match: VariantMatch,
+        annotation: Optional[dict],
+        gene_hpos: Mapping[str, Set[str]],
+        sample_hpos: Set[str],
+) -> Dict[str, Any]:
+    annotation = annotation or {}
+    clinvar = annotation.get("clinvar") or {}
+    gene = annotation.get("gene") or ""
+
+    return {
+        "Input_variant": result.request.variant,
+        "Input_format": result.request.representation_type or "",
+        "Candidate_ID": candidate.candidate_id,
+        "Candidate_variant": candidate.get_genomic_variant(),
+        "Normalized_variant": candidate.get_normalized_variant() or "",
+        "Found_in_sample": "Yes" if variant_match.found else "No",
+        "Variant": variant_match.get_variant(),
+        "Gene": gene,
+        "Genotype": variant_match.genotype or "",
+        "Zygosity": _classify_zygosity(
+            variant_match.genotype
+        ),
+        "rs": annotation.get("dbsnp") or "",
+        "Transcript": annotation.get("transcript") or "",
+        "HGVSC": annotation.get("hgvsc") or "",
+        "HGVSP": annotation.get("hgvsp") or "",
+        "Consequence": annotation.get("consequence") or "",
+        "GeneBe_ACMG_Classification": (
+                annotation.get("acmg_classification") or ""
+        ),
+        "GeneBe_ACMG_criteria": _join_values(
+            annotation.get("acmg_criteria")
+        ),
+        "ClinvarClinicalSignificance": (
+                clinvar.get("clinical_significance") or ""
+        ),
+        "ReviewStatus": clinvar.get("review_status") or "",
+        "ClinvarID": clinvar.get("variation_id") or "",
+        "Quality": (
+            "" if variant_match.quality is None else variant_match.quality
+        ),
+        "Filter": _join_values(variant_match.filters),
+        "related_HPOs_for_sample": _get_related_hpos(
+            gene=gene,
+            gene_hpos=gene_hpos,
+            sample_hpos=sample_hpos,
+        ),
+        "VCF_Sample_FORMAT": _format_sample_format(
+            variant_match.sample_format
+        ),
+        "Conversion_warnings": _join_values(
+            candidate.conversion_warnings
+        ),
+        "Match_warnings": _join_values(
+            variant_match.warnings
+        ),
+    }
+
+
+def _load_gene_hpos(
+        gene_to_phenotype_file: str | Path,
+) -> Dict[str, Set[str]]:
+    """
+    Load the same gene-to-phenotype resource used by PR/RR reporting.
+
+    Only direct intersections with the sample HPO list are reported, matching
+    the current behaviour of ``add_patient_HPOterms``.
+    """
+    gene_to_phenotype_file = Path(gene_to_phenotype_file)
+    gene_hpos: Dict[str, Set[str]] = {}
+
+    with gene_to_phenotype_file.open(
+            "r",
+            encoding="utf-8",
+    ) as handle:
+        next(handle, None)
+
+        for line_number, line in enumerate(handle, start=2):
+            fields = line.rstrip("\n").split("\t")
+
+            if len(fields) < 3:
+                raise ValueError(
+                    "Invalid gene-to-phenotype row at "
+                    f"{gene_to_phenotype_file}:{line_number}"
+                )
+
+            gene_symbol = fields[1].strip()
+            hpo_id = fields[2].strip()
+
+            if not gene_symbol or not hpo_id:
+                continue
+
+            gene_hpos.setdefault(
+                gene_symbol,
+                set(),
+            ).add(
+                hpo_id
+            )
+
+    return gene_hpos
+
+
+def _get_related_hpos(
+        gene: str,
+        gene_hpos: Mapping[str, Set[str]],
+        sample_hpos: Set[str],
+) -> str:
+    if not gene or not sample_hpos:
+        return NOT_AVAILABLE
+
+    related_hpos = sorted(
+        gene_hpos.get(gene, set()) & sample_hpos
+    )
+
+    return (
+        ",".join(related_hpos)
+        if related_hpos
+        else NOT_AVAILABLE
+    )
+
+
+def _classify_zygosity(
+        genotype: Optional[str],
+) -> str:
+    if not genotype or genotype in {".", "./.", ".|."}:
+        return ""
+
+    separator = (
+        "/"
+        if "/" in genotype
+        else "|"
+        if "|" in genotype
+        else None
+    )
+
+    if separator is None:
+        # Haploid alternate genotype, typically on sex chromosomes.
+        return "HEMI" if genotype not in {"0", "."} else ""
+
+    alleles = genotype.split(separator)
+
+    if len(alleles) != 2 or "." in alleles:
+        return ""
+
+    if alleles[0] == alleles[1]:
+        return "HOM"
+
+    return "HET"
+
+
+def _format_sample_format(
+        sample_format: Mapping[str, Any],
+) -> str:
+    """
+    Serialize all patient VCF FORMAT fields into one Excel-safe value.
+
+    Example:
+        GT=0/1; AD=46,38; DP=84; GQ=99
+    """
+    if not sample_format:
+        return ""
+
+    return "; ".join(
+        f"{key}={_format_value(value)}"
+        for key, value in sample_format.items()
+    )
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return ""
+
+    if isinstance(value, (list, tuple)):
+        return ",".join(
+            str(item)
+            for item in value
+        )
+
+    return str(value)
+
+
+def _join_values(
+        values: Any,
+) -> str:
+    if values is None:
+        return ""
+
+    if isinstance(values, str):
+        return values
+
+    if isinstance(values, Iterable):
+        return ",".join(
+            str(value)
+            for value in values
+        )
+
+    return str(values)

--- a/tests/report/test_variant_confirmation_table.py
+++ b/tests/report/test_variant_confirmation_table.py
@@ -1,0 +1,254 @@
+from types import SimpleNamespace
+
+import pytest
+
+from sftool.report.variant_confirmation_table import (
+    build_variant_confirmation_table,
+)
+from sftool.variant_confirmation.models import (
+    VariantCandidate,
+    VariantConfirmationRequest,
+    VariantConfirmationResult,
+    VariantMatch,
+)
+
+
+def _build_ctx(gene_to_phenotype_file):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            references=SimpleNamespace(
+                gene_to_phenotype_file=str(gene_to_phenotype_file)
+            )
+        )
+    )
+
+
+def _build_sample(result, hpo_terms=None):
+    return SimpleNamespace(
+        results={"variant_confirmation": result},
+        hpo_terms=hpo_terms or [],
+    )
+
+
+def _build_result(
+        *,
+        found=True,
+        annotations=None,
+        genotype="0/1",
+        sample_format=None,
+):
+    request = VariantConfirmationRequest(
+        variant="NM_000546.6:c.215C>G",
+        representation_type="hgvsc",
+    )
+
+    candidate = VariantCandidate(
+        candidate_id="candidate_1",
+        chromosome="17",
+        position=7676154,
+        reference="G",
+        alternate="C",
+        assembly="GRCh38",
+    )
+    candidate.set_normalized_coordinates(
+        chromosome="17",
+        position=7676154,
+        reference="G",
+        alternate="C",
+    )
+
+    variant_match = VariantMatch(
+        candidate_id="candidate_1",
+        chromosome="17",
+        position=7676154,
+        reference="G",
+        alternate="C",
+        found=False,
+    )
+
+    if found:
+        variant_match.set_match_data(
+            genotype=genotype,
+            quality=99.0,
+            filters=["PASS"],
+            sample_format=sample_format or {
+                "GT": genotype,
+                "AD": [46, 38],
+                "DP": 84,
+                "GQ": 99,
+            },
+        )
+
+    for annotation in annotations or []:
+        variant_match.add_annotation(annotation)
+
+    result = VariantConfirmationResult(request)
+    result.add_candidate(candidate)
+    result.add_match(variant_match)
+
+    return result
+
+
+def test_build_variant_confirmation_table_includes_annotation_format_and_hpo(
+        tmp_path,
+):
+    """
+    Verify that a detected diagnostic variant with GeneBe annotations is
+    correctly converted into a single report row including:
+
+    - input representation
+    - GeneBe annotation fields
+    - ClinVar information
+    - genotype and zygosity
+    - FORMAT serialization
+    - related sample HPO terms
+    """
+
+    gene_hpo_file = tmp_path / "genes_to_phenotype.txt"
+    gene_hpo_file.write_text(
+        "ncbi_gene_id\tgene_symbol\thpo_id\n"
+        "7157\tTP53\tHP:0002664\n"
+        "7157\tTP53\tHP:0003002\n",
+        encoding="utf-8",
+    )
+
+    result = _build_result(
+        annotations=[
+            {
+                "gene": "TP53",
+                "transcript": "NM_000546.6",
+                "consequence": "missense_variant",
+                "hgvsc": "NM_000546.6:c.215C>G",
+                "hgvsp": "NP_000537.3:p.Pro72Arg",
+                "dbsnp": "rs1042522",
+                "acmg_classification": "Pathogenic",
+                "acmg_criteria": ["PS3", "PM2"],
+                "clinvar": {
+                    "clinical_significance": "Pathogenic",
+                    "review_status": "reviewed_by_expert_panel",
+                    "variation_id": "12345",
+                },
+            }
+        ]
+    )
+
+    table = build_variant_confirmation_table(
+        _build_ctx(gene_hpo_file),
+        _build_sample(
+            result,
+            hpo_terms=["HP:0002664", "HP:9999999"],
+        ),
+    )
+
+    assert table.tab_name == "Variant confirmation"
+    assert len(table.rows) == 1
+
+    row = table.rows[0]
+
+    assert row["Input_variant"] == "NM_000546.6:c.215C>G"
+    assert row["Input_format"] == "hgvsc"
+    assert row["Found_in_sample"] == "Yes"
+    assert row["Gene"] == "TP53"
+    assert row["Genotype"] == "0/1"
+    assert row["Zygosity"] == "HET"
+    assert row["related_HPOs_for_sample"] == "HP:0002664"
+    assert row["VCF_Sample_FORMAT"] == (
+        "GT=0/1; AD=46,38; DP=84; GQ=99"
+    )
+
+
+def test_build_variant_confirmation_table_keeps_not_found_candidate(
+        tmp_path,
+):
+    """
+    Verify that diagnostic candidates not detected in the patient VCF are still
+    included in the report with sample-dependent fields left empty.
+    """
+
+    gene_hpo_file = tmp_path / "genes_to_phenotype.txt"
+    gene_hpo_file.write_text(
+        "ncbi_gene_id\tgene_symbol\thpo_id\n",
+        encoding="utf-8",
+    )
+
+    table = build_variant_confirmation_table(
+        _build_ctx(gene_hpo_file),
+        _build_sample(
+            _build_result(found=False)
+        ),
+    )
+
+    assert len(table.rows) == 1
+
+    row = table.rows[0]
+
+    assert row["Found_in_sample"] == "No"
+    assert row["Gene"] == ""
+    assert row["Genotype"] == ""
+    assert row["Zygosity"] == ""
+    assert row["VCF_Sample_FORMAT"] == ""
+    assert row["related_HPOs_for_sample"] == "NA"
+
+
+def test_build_variant_confirmation_table_creates_one_row_per_annotation(
+        tmp_path,
+):
+
+    """
+    Verify that one report row is generated for every GeneBe annotation
+    associated with the same diagnostic candidate.
+    """
+    gene_hpo_file = tmp_path / "genes_to_phenotype.txt"
+    gene_hpo_file.write_text(
+        "ncbi_gene_id\tgene_symbol\thpo_id\n"
+        "1\tGENE1\tHP:0000001\n"
+        "2\tGENE2\tHP:0000002\n",
+        encoding="utf-8",
+    )
+
+    result = _build_result(
+        annotations=[
+            {"gene": "GENE1", "clinvar": {}},
+            {"gene": "GENE2", "clinvar": {}},
+        ]
+    )
+
+    table = build_variant_confirmation_table(
+        _build_ctx(gene_hpo_file),
+        _build_sample(
+            result,
+            hpo_terms=["HP:0000001", "HP:0000002"],
+        ),
+    )
+
+    assert [row["Gene"] for row in table.rows] == [
+        "GENE1",
+        "GENE2",
+    ]
+    assert [
+               row["related_HPOs_for_sample"]
+               for row in table.rows
+           ] == [
+               "HP:0000001",
+               "HP:0000002",
+           ]
+
+
+def test_build_variant_confirmation_table_returns_none_without_result(
+        tmp_path,
+):
+    gene_hpo_file = tmp_path / "genes_to_phenotype.txt"
+    gene_hpo_file.write_text(
+        "ncbi_gene_id\tgene_symbol\thpo_id\n",
+        encoding="utf-8",
+    )
+
+    sample = SimpleNamespace(
+        results={},
+        hpo_terms=[],
+    )
+
+    assert build_variant_confirmation_table(
+        _build_ctx(gene_hpo_file),
+        sample,
+    ) is None


### PR DESCRIPTION
## Summary
This PR extends the reporting layer to include the results generated by the Variant Confirmation workflow.

A new **"Variant confirmation"** worksheet is added to the per-sample Excel report, allowing users to review the requested diagnostic variant together with its matching status, annotation and patient genotype information using the same reporting philosophy as the existing PR/RR sections.

## Main changes

### Variant Confirmation worksheet

A new worksheet named **Variant confirmation** is generated when Variant Confirmation is enabled for a sample. Each row corresponds to one candidate variant and one associated GeneBe annotation.

---

### Reporting integration

The new worksheet has been integrated into the existing reporting pipeline without modifying the Excel writer implementation.

The report generation now automatically includes the Variant Confirmation worksheet whenever a `VariantConfirmationResult` is available for the sample.

---

### HPO integration

The report reuses the same gene-to-phenotype resource already used by PR/RR reporting to populate the `related_HPOs_for_sample` field.

Only HPO terms shared between the sample and the reported gene are displayed.

---

### Negative results

Diagnostic candidates that are **not found** in the patient VCF are still included in the report.


## Related Issue
Refs #48 

## Type of change
- [X] Feature (feat)
- [ ] Bug fix (fix)
- [X] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [X] Tests
- [ ] Maintenance / Chore

## Checklist
- [ ] Code compiles and runs
- [X] Tests added or updated
- [ ] Documentation updated
- [X] Linked the related issue (e.g., "Refs #48 ")
