### PR TITLE
Phase 7 — ClinVar enrichment for Variant Confirmation

### DIFF
--- a/sftool/commands/run.py
+++ b/sftool/commands/run.py
@@ -103,7 +103,10 @@ def run(samples_path, config_path, outdir, force, debug_dump_ctx, debug_load_ctx
             c for s in ctx.samples for c in s.categories
         })
 
-        if 'clinvar' in variant_classification_sources and ("PR" in categories or "RR" in categories):
+        if ('clinvar' in variant_classification_sources and ("PR" in categories or "RR" in categories)) \
+                or \
+                "variant_confirmation" in ctx.modes:
+
             run_clinvar_setup(ctx)
 
 

--- a/sftool/report/variant_confirmation_table.py
+++ b/sftool/report/variant_confirmation_table.py
@@ -82,7 +82,7 @@ def _build_report_row(
         sample_hpos: Set[str],
 ) -> Dict[str, Any]:
     annotation = annotation or {}
-    clinvar = annotation.get("clinvar") or {}
+    clinvar = variant_match.clinvar or {}
     gene = annotation.get("gene") or ""
 
     return {
@@ -98,7 +98,11 @@ def _build_report_row(
         "Zygosity": _classify_zygosity(
             variant_match.genotype
         ),
-        "rs": annotation.get("dbsnp") or "",
+        "rs": (
+                annotation.get("dbsnp")
+                or clinvar.get("rs")
+                or ""
+        ),
         "Transcript": annotation.get("transcript") or "",
         "HGVSC": annotation.get("hgvsc") or "",
         "HGVSP": annotation.get("hgvsp") or "",
@@ -110,10 +114,23 @@ def _build_report_row(
             annotation.get("acmg_criteria")
         ),
         "ClinvarClinicalSignificance": (
-                clinvar.get("clinical_significance") or ""
+                clinvar.get("clinical_significance") or NOT_AVAILABLE
         ),
-        "ReviewStatus": clinvar.get("review_status") or "",
-        "ClinvarID": clinvar.get("variation_id") or "",
+        "ClinvarSummary": (
+                clinvar.get("clinical_significance_summary") or NOT_AVAILABLE
+        ),
+        "ReviewStatus": (
+                clinvar.get("review_status") or NOT_AVAILABLE
+        ),
+        "ClinvarID": (
+                clinvar.get("clinvar_id") or NOT_AVAILABLE
+        ),
+        "Orpha": (
+                clinvar.get("orpha") or NOT_AVAILABLE
+        ),
+        "OMIM_clinvar": (
+                clinvar.get("omim") or NOT_AVAILABLE
+        ),
         "Quality": (
             "" if variant_match.quality is None else variant_match.quality
         ),

--- a/sftool/steps/variant_confirmation.py
+++ b/sftool/steps/variant_confirmation.py
@@ -17,6 +17,9 @@ from sftool.variant_confirmation.utils import (
     store_variant_confirmation_outputs,
     write_conversion_json,
 )
+from sftool.variant_confirmation.clinvar_lookup import (
+    VariantConfirmationClinVarLookup,
+)
 
 
 def run(ctx: ExecutionContext) -> None:
@@ -41,6 +44,8 @@ def run(ctx: ExecutionContext) -> None:
     )
 
     result_builder = VariantConfirmationResultBuilder()
+
+    clinvar_lookup = VariantConfirmationClinVarLookup()
 
     for sample in ctx.samples:
         request = sample.variant_confirmation_request
@@ -106,7 +111,23 @@ def run(ctx: ExecutionContext) -> None:
                 output_dir=output_dir,
             )
 
-        # 6. Build and serialize the structured result.
+        # 6. Retrieve variant-level ClinVar evidence.
+        clinvar_by_candidate = clinvar_lookup.lookup(
+            matches=matching_output.matches,
+            clinvar_db=ctx.outputs["clinvar"]["clinvar_db"],
+            clinvar_submission_db=(
+                ctx.outputs["clinvar"]["clinvar_summary_db"]
+            ),
+        )
+
+        for variant_match in matching_output.matches:
+            variant_match.set_clinvar(
+                clinvar_by_candidate.get(
+                    variant_match.candidate_id
+                )
+            )
+
+        # 7. Build and serialize the structured result.
         structured_output = result_builder.build_to_directory(
             request=parsed_request,
             candidates=candidates,
@@ -115,7 +136,7 @@ def run(ctx: ExecutionContext) -> None:
             output_directory=output_dir,
         )
 
-        # 7. Store paths and in-memory result in SampleContext.
+        # 8. Store paths and in-memory result in SampleContext.
         store_variant_confirmation_outputs(
             sample=sample,
             conversion_json=conversion_json,

--- a/sftool/variant_confirmation/clinvar_lookup.py
+++ b/sftool/variant_confirmation/clinvar_lookup.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import re
+
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Set, Tuple
+
+from sftool.utils.clinvar_utils import map_review_status
+from sftool.variant_confirmation.models import VariantMatch
+
+
+VariantKey = Tuple[str, int, str, str]
+
+
+class ClinVarLookupError(RuntimeError):
+    """
+    Raised when Variant Confirmation ClinVar lookup cannot be completed.
+    """
+
+
+class VariantConfirmationClinVarLookup:
+    """
+    Retrieve ClinVar information for detected Variant Confirmation matches.
+
+    The lookup uses exact normalized genomic coordinates:
+
+        CHROM + POS + REF + ALT
+
+    No gene catalogue or ``clinvar_evidence`` threshold is applied. Every
+    matching ClinVar entry is returned regardless of review status or clinical
+    significance.
+    """
+
+    ALLOWED_VARIANT_TYPES = {
+        "deletion",
+        "duplication",
+        "insertion",
+        "indel",
+        "single nucleotide variant",
+        "microsatellite",
+        "variation",
+    }
+
+    def lookup(
+            self,
+            matches: Sequence[VariantMatch],
+            clinvar_db: str | Path,
+            clinvar_submission_db: str | Path,
+    ) -> Dict[str, dict]:
+        """
+        Return ClinVar annotations indexed by Variant Confirmation candidate ID.
+
+        Only matches detected in the patient VCF are queried. Candidates not
+        found in the sample are omitted from the result.
+        """
+        validated_matches = self._validate_matches(matches)
+        clinvar_db = self._validate_file(clinvar_db, "ClinVar variant database")
+        clinvar_submission_db = self._validate_file(
+            clinvar_submission_db,
+            "ClinVar submission summary database",
+        )
+
+        candidate_ids_by_key = self._index_detected_matches(
+            validated_matches
+        )
+
+        if not candidate_ids_by_key:
+            return {}
+
+        annotations = self._read_variant_annotations(
+            clinvar_db=clinvar_db,
+            candidate_ids_by_key=candidate_ids_by_key,
+        )
+
+        variation_ids = {
+            str(annotation["clinvar_id"])
+            for annotation in annotations.values()
+            if annotation.get("clinvar_id") not in (None, "")
+        }
+
+        summaries = self._read_submission_summaries(
+            clinvar_submission_db=clinvar_submission_db,
+            variation_ids=variation_ids,
+        )
+
+        for annotation in annotations.values():
+            clinvar_id = str(
+                annotation.get("clinvar_id", "")
+            )
+            annotation["clinical_significance_summary"] = summaries.get(
+                clinvar_id,
+                "",
+            )
+
+        return annotations
+
+    @staticmethod
+    def _validate_matches(
+            matches: Sequence[VariantMatch],
+    ) -> list[VariantMatch]:
+        if isinstance(matches, (str, bytes)):
+            raise TypeError(
+                "matches must be a sequence of VariantMatch objects"
+            )
+
+        if not isinstance(matches, Sequence):
+            raise TypeError(
+                "matches must be a sequence of VariantMatch objects"
+            )
+
+        validated_matches = list(matches)
+
+        for index, variant_match in enumerate(
+                validated_matches,
+                start=1,
+        ):
+            if not isinstance(variant_match, VariantMatch):
+                raise TypeError(
+                    f"Match {index} must be a VariantMatch, "
+                    f"got {type(variant_match).__name__}"
+                )
+
+        return validated_matches
+
+    @staticmethod
+    def _validate_file(
+            path: str | Path,
+            description: str,
+    ) -> Path:
+        if not isinstance(path, (str, Path)):
+            raise TypeError(
+                f"{description} path must be a string or pathlib.Path"
+            )
+
+        path = Path(path)
+
+        if not path.is_file():
+            raise FileNotFoundError(
+                f"{description} not found: {path}"
+            )
+
+        return path
+
+    def _index_detected_matches(
+            self,
+            matches: Iterable[VariantMatch],
+    ) -> Dict[VariantKey, str]:
+        candidate_ids_by_key: Dict[VariantKey, str] = {}
+
+        for variant_match in matches:
+            if not variant_match.found:
+                continue
+
+            key = self._build_variant_key(
+                chromosome=variant_match.chromosome,
+                position=variant_match.position,
+                reference=variant_match.reference,
+                alternate=variant_match.alternate,
+            )
+
+            if key in candidate_ids_by_key:
+                raise ClinVarLookupError(
+                    "Detected Variant Confirmation matches contain duplicated "
+                    f"normalized coordinates: {self._format_key(key)}"
+                )
+
+            candidate_ids_by_key[key] = variant_match.candidate_id
+
+        return candidate_ids_by_key
+
+    def _read_variant_annotations(
+            self,
+            clinvar_db: Path,
+            candidate_ids_by_key: Mapping[VariantKey, str],
+    ) -> Dict[str, dict]:
+        annotations: Dict[str, dict] = {}
+
+        try:
+            with clinvar_db.open(
+                    "r",
+                    encoding="utf-8",
+                    newline="",
+            ) as handle:
+                reader = csv.DictReader(
+                    handle,
+                    delimiter="\t",
+                )
+
+                self._validate_variant_database_header(
+                    reader.fieldnames
+                )
+
+                for row in reader:
+                    annotation = self._parse_variant_row(row)
+
+                    if annotation is None:
+                        continue
+
+                    key = annotation.pop("_variant_key")
+                    candidate_id = candidate_ids_by_key.get(key)
+
+                    if candidate_id is None:
+                        continue
+
+                    if candidate_id in annotations:
+                        raise ClinVarLookupError(
+                            "More than one ClinVar record was found for "
+                            f"candidate {candidate_id!r} at "
+                            f"{self._format_key(key)}"
+                        )
+
+                    annotations[candidate_id] = annotation
+
+        except ClinVarLookupError:
+            raise
+        except (OSError, csv.Error, ValueError) as exc:
+            raise ClinVarLookupError(
+                f"Could not parse ClinVar variant database {clinvar_db}: {exc}"
+            ) from exc
+
+        return annotations
+
+    def _parse_variant_row(
+            self,
+            row: Mapping[str, str],
+    ) -> Optional[dict]:
+        variant_type = (
+                row.get("Type") or ""
+        ).strip().lower()
+
+        if variant_type not in self.ALLOWED_VARIANT_TYPES:
+            return None
+
+        position = (
+                row.get("PositionVCF") or ""
+        ).strip()
+
+        if not position or position == "-1":
+            return None
+
+        try:
+            position_value = int(position)
+        except ValueError as exc:
+            raise ClinVarLookupError(
+                f"Invalid ClinVar PositionVCF value: {position!r}"
+            ) from exc
+
+        chromosome = (
+                row.get("Chromosome") or ""
+        ).strip()
+        reference = (
+                row.get("ReferenceAlleleVCF") or ""
+        ).strip()
+        alternate = (
+                row.get("AlternateAlleleVCF") or ""
+        ).strip()
+
+        if not chromosome or not reference or not alternate:
+            return None
+
+        key = self._build_variant_key(
+            chromosome=chromosome,
+            position=position_value,
+            reference=reference,
+            alternate=alternate,
+        )
+
+        review_status = (
+                row.get("ReviewStatus") or ""
+        ).strip()
+
+        stars = (
+            map_review_status(review_status)
+            if review_status
+            else 0
+        )
+
+        phenotype_ids = (
+                row.get("PhenotypeIDS") or ""
+        ).strip()
+
+        rs_number = (
+                row.get("RS# (dbSNP)") or ""
+        ).strip()
+
+        return {
+            "_variant_key": key,
+            "variant_name": (
+                    row.get("Name") or ""
+            ).strip(),
+            "gene": (
+                    row.get("GeneSymbol") or ""
+            ).strip(),
+            "clinical_significance": (
+                    row.get("ClinicalSignificance") or ""
+            ).strip(),
+            "clin_sig_simple": (
+                    row.get("ClinSigSimple") or ""
+            ).strip(),
+            "rs": self._format_rs(rs_number),
+            "review_status": (
+                f"({stars}) {review_status}"
+                if review_status
+                else ""
+            ),
+            "stars": stars,
+            "clinvar_id": (
+                    row.get("VariationID") or ""
+            ).strip(),
+            "phenotype_ids": phenotype_ids,
+            "phenotype_list": (
+                    row.get("PhenotypeList") or ""
+            ).strip(),
+            "orpha": self._extract_identifiers(
+                phenotype_ids,
+                r"Orphanet:(\d+)",
+            ),
+            "omim": self._extract_identifiers(
+                phenotype_ids,
+                r"OMIM:\s*([^,|;]+)",
+            ),
+        }
+
+    def _read_submission_summaries(
+            self,
+            clinvar_submission_db: Path,
+            variation_ids: Set[str],
+    ) -> Dict[str, str]:
+        if not variation_ids:
+            return {}
+
+        counts: Dict[str, Dict[str, int]] = {
+            variation_id: {}
+            for variation_id in variation_ids
+        }
+
+        try:
+            with gzip.open(
+                    clinvar_submission_db,
+                    "rt",
+                    encoding="utf-8",
+                    newline="",
+            ) as handle:
+                header = self._find_submission_header(handle)
+                reader = csv.DictReader(
+                    handle,
+                    fieldnames=header,
+                    delimiter="\t",
+                )
+
+                for row in reader:
+                    variation_id = (
+                            row.get("VariationID") or ""
+                    ).strip()
+
+                    if variation_id not in counts:
+                        continue
+
+                    contributes = (
+                            row.get("ContributesToAggregateClassification") or ""
+                    ).strip().lower()
+
+                    if contributes != "yes":
+                        continue
+
+                    significance = (
+                            row.get("ClinicalSignificance") or ""
+                    ).strip()
+
+                    if not significance:
+                        continue
+
+                    current_counts = counts[variation_id]
+                    current_counts[significance] = (
+                            current_counts.get(significance, 0) + 1
+                    )
+
+        except ClinVarLookupError:
+            raise
+        except (OSError, csv.Error) as exc:
+            raise ClinVarLookupError(
+                "Could not parse ClinVar submission summary database "
+                f"{clinvar_submission_db}: {exc}"
+            ) from exc
+
+        return {
+            variation_id: "; ".join(
+                f"{significance} ({count})"
+                for significance, count in significance_counts.items()
+            )
+            for variation_id, significance_counts in counts.items()
+            if significance_counts
+        }
+
+    @staticmethod
+    def _find_submission_header(
+            handle,
+    ) -> list[str]:
+        for line in handle:
+            if not line.startswith("#"):
+                continue
+
+            fields = line.lstrip("#").rstrip("\n").split("\t")
+
+            if "VariationID" in fields:
+                return fields
+
+        raise ClinVarLookupError(
+            "ClinVar submission summary header was not found"
+        )
+
+    @staticmethod
+    def _validate_variant_database_header(
+            fieldnames: Optional[Sequence[str]],
+    ) -> None:
+        required_fields = {
+            "Type",
+            "Name",
+            "GeneSymbol",
+            "ClinicalSignificance",
+            "ClinSigSimple",
+            "RS# (dbSNP)",
+            "VariationID",
+            "PhenotypeIDS",
+            "PhenotypeList",
+            "Chromosome",
+            "ReviewStatus",
+            "PositionVCF",
+            "ReferenceAlleleVCF",
+            "AlternateAlleleVCF",
+        }
+
+        available_fields = set(fieldnames or [])
+        missing_fields = required_fields - available_fields
+
+        if missing_fields:
+            raise ClinVarLookupError(
+                "ClinVar variant database is missing required columns: "
+                + ", ".join(sorted(missing_fields))
+            )
+
+    @staticmethod
+    def _build_variant_key(
+            chromosome: str,
+            position: int,
+            reference: str,
+            alternate: str,
+    ) -> VariantKey:
+        chromosome = str(chromosome).strip()
+
+        if chromosome.lower().startswith("chr"):
+            chromosome = chromosome[3:]
+
+        return (
+            chromosome,
+            int(position),
+            str(reference).strip().upper(),
+            str(alternate).strip().upper(),
+        )
+
+    @staticmethod
+    def _format_key(
+            key: VariantKey,
+    ) -> str:
+        chromosome, position, reference, alternate = key
+
+        return (
+            f"{chromosome}:{position}:{reference}:{alternate}"
+        )
+
+    @staticmethod
+    def _format_rs(
+            rs_number: str,
+    ) -> str:
+        if not rs_number or rs_number in {"-1", "."}:
+            return ""
+
+        if rs_number.lower().startswith("rs"):
+            return rs_number
+
+        return f"rs{rs_number}"
+
+    @staticmethod
+    def _extract_identifiers(
+            value: str,
+            pattern: str,
+    ) -> str:
+        return ",".join(
+            dict.fromkeys(
+                match.strip()
+                for match in re.findall(pattern, value)
+                if match.strip()
+            )
+        )

--- a/sftool/variant_confirmation/models.py
+++ b/sftool/variant_confirmation/models.py
@@ -384,6 +384,10 @@ class VariantMatch:
         # A variant may have annotations for multiple genes/transcripts.
         self.annotations: List[dict] = []
 
+        # ClinVar is variant-level evidence and is stored separately from
+        # GeneBe gene/transcript annotations.
+        self.clinvar: Optional[dict] = None
+
         self.warnings: List[str] = []
 
     def set_match_data(
@@ -411,6 +415,19 @@ class VariantMatch:
             raise TypeError("annotation must be a dictionary")
 
         self.annotations.append(dict(annotation))
+
+    def set_clinvar(self, clinvar: Optional[dict]):
+        """
+        Store variant-level ClinVar information for this patient VCF match.
+        """
+        if clinvar is not None and not isinstance(clinvar, dict):
+            raise TypeError("clinvar must be a dictionary or None")
+
+        self.clinvar = (
+            deepcopy(clinvar)
+            if clinvar
+            else None
+        )
 
     def add_warning(self, warning: str):
         warning = VariantCandidate._validate_non_empty_string(
@@ -455,6 +472,7 @@ class VariantMatch:
             "annotations": deepcopy(
                 self.annotations
             ),
+            "clinvar": deepcopy(self.clinvar),
             "warnings": self.warnings.copy(),
         }
 

--- a/sftool/variant_confirmation/result_builder.py
+++ b/sftool/variant_confirmation/result_builder.py
@@ -557,9 +557,6 @@ class VariantConfirmationResultBuilder:
             "acmg_criteria": self._split_acmg_criteria(
                 values[7]
             ),
-            "clinvar": self._build_clinvar_annotation(
-                record.INFO
-            ),
         }
 
     def _build_minimal_annotation(
@@ -581,53 +578,8 @@ class VariantConfirmationResultBuilder:
             ),
             "acmg_classification": None,
             "acmg_criteria": [],
-            "clinvar": self._build_clinvar_annotation(
-                record.INFO
-            ),
         }
 
-    def _build_clinvar_annotation(
-            self,
-            info: Dict[str, Any],
-    ) -> dict:
-        clinical_significance = self._get_first_available_info_value(
-            info,
-            (
-                "clinvar_clinical_significance",
-                "clinvar_significance",
-                "clinical_significance",
-                "clinvar_classification",
-            ),
-        )
-
-        review_status = self._get_first_available_info_value(
-            info,
-            (
-                "clinvar_review_status",
-                "review_status",
-            ),
-        )
-
-        variation_id = self._get_first_available_info_value(
-            info,
-            (
-                "clinvar_variation_id",
-                "clinvar_id",
-                "variation_id",
-            ),
-        )
-
-        clinvar = {
-            "clinical_significance": clinical_significance,
-            "review_status": review_status,
-            "variation_id": variation_id,
-        }
-
-        return {
-            key: value
-            for key, value in clinvar.items()
-            if value is not None
-        }
 
     def _attach_annotations(
             self,

--- a/tests/variant_confirmation/test_clinvar_lookup.py
+++ b/tests/variant_confirmation/test_clinvar_lookup.py
@@ -1,0 +1,217 @@
+import gzip
+
+from sftool.variant_confirmation.clinvar_lookup import (
+    VariantConfirmationClinVarLookup,
+)
+from sftool.variant_confirmation.models import VariantMatch
+
+
+def _write_clinvar_database(path):
+    path.write_text(
+        "\t".join([
+            "Type",
+            "Name",
+            "GeneSymbol",
+            "ClinicalSignificance",
+            "ClinSigSimple",
+            "RS# (dbSNP)",
+            "VariationID",
+            "PhenotypeIDS",
+            "PhenotypeList",
+            "Assembly",
+            "Chromosome",
+            "Start",
+            "Stop",
+            "ReviewStatus",
+            "SubmitterCategories",
+            "PositionVCF",
+            "ReferenceAlleleVCF",
+            "AlternateAlleleVCF",
+        ])
+        + "\n"
+        + "\t".join([
+            "single nucleotide variant",
+            "NM_000546.6(TP53):c.215C>G",
+            "TP53",
+            "Pathogenic",
+            "1",
+            "1042522",
+            "12345",
+            "Orphanet:524;OMIM:151623",
+            "Li-Fraumeni syndrome",
+            "GRCh38",
+            "17",
+            "7676154",
+            "7676154",
+            "reviewed by expert panel",
+            "3",
+            "7676154",
+            "G",
+            "C",
+        ])
+        + "\n",
+        encoding="utf-8",
+        )
+
+
+def _write_submission_database(path):
+    with gzip.open(
+            path,
+            "wt",
+            encoding="utf-8",
+    ) as handle:
+        handle.write(
+            "#VariationID\tClinicalSignificance\t"
+            "ContributesToAggregateClassification\n"
+        )
+        handle.write(
+            "12345\tPathogenic\tyes\n"
+        )
+        handle.write(
+            "12345\tLikely pathogenic\tyes\n"
+        )
+        handle.write(
+            "12345\tBenign\tno\n"
+        )
+
+
+def _build_match(
+        *,
+        candidate_id="candidate_1",
+        found=True,
+        chromosome="chr17",
+        position=7676154,
+        reference="G",
+        alternate="C",
+):
+    variant_match = VariantMatch(
+        candidate_id=candidate_id,
+        chromosome=chromosome,
+        position=position,
+        reference=reference,
+        alternate=alternate,
+        found=False,
+    )
+
+    if found:
+        variant_match.set_match_data(
+            genotype="0/1",
+            quality=99.0,
+            filters=["PASS"],
+            sample_format={"GT": "0/1"},
+        )
+
+    return variant_match
+
+
+def test_lookup_returns_complete_clinvar_annotation_without_evidence_filter(
+        tmp_path,
+):
+    """
+    Verify that an exact detected candidate retrieves the complete ClinVar
+    annotation and submission summary without applying clinvar_evidence.
+    """
+    clinvar_db = tmp_path / "clinvar_database_GRCh38.txt"
+    submission_db = tmp_path / "clinvar_submission.txt.gz"
+
+    _write_clinvar_database(clinvar_db)
+    _write_submission_database(submission_db)
+
+    annotations = VariantConfirmationClinVarLookup().lookup(
+        matches=[_build_match()],
+        clinvar_db=clinvar_db,
+        clinvar_submission_db=submission_db,
+    )
+
+    annotation = annotations["candidate_1"]
+
+    assert annotation["clinical_significance"] == "Pathogenic"
+    assert annotation["review_status"] == (
+        "(3) reviewed by expert panel"
+    )
+    assert annotation["stars"] == 3
+    assert annotation["clinvar_id"] == "12345"
+    assert annotation["rs"] == "rs1042522"
+    assert annotation["orpha"] == "524"
+    assert annotation["omim"] == "151623"
+    assert annotation["clinical_significance_summary"] == (
+        "Pathogenic (1); Likely pathogenic (1)"
+    )
+
+
+def test_lookup_matches_coordinates_ignoring_chr_prefix(
+        tmp_path,
+):
+    """
+    Verify that candidate and ClinVar chromosomes match when only the candidate
+    contains the conventional ``chr`` prefix.
+    """
+    clinvar_db = tmp_path / "clinvar_database_GRCh38.txt"
+    submission_db = tmp_path / "clinvar_submission.txt.gz"
+
+    _write_clinvar_database(clinvar_db)
+    _write_submission_database(submission_db)
+
+    annotations = VariantConfirmationClinVarLookup().lookup(
+        matches=[
+            _build_match(
+                chromosome="chr17",
+            )
+        ],
+        clinvar_db=clinvar_db,
+        clinvar_submission_db=submission_db,
+    )
+
+    assert "candidate_1" in annotations
+
+
+def test_lookup_ignores_candidates_not_detected_in_patient_vcf(
+        tmp_path,
+):
+    """
+    Verify that candidates not found in the patient VCF are not queried or
+    annotated with ClinVar information.
+    """
+    clinvar_db = tmp_path / "clinvar_database_GRCh38.txt"
+    submission_db = tmp_path / "clinvar_submission.txt.gz"
+
+    _write_clinvar_database(clinvar_db)
+    _write_submission_database(submission_db)
+
+    annotations = VariantConfirmationClinVarLookup().lookup(
+        matches=[
+            _build_match(
+                found=False,
+            )
+        ],
+        clinvar_db=clinvar_db,
+        clinvar_submission_db=submission_db,
+    )
+
+    assert annotations == {}
+
+
+def test_lookup_returns_empty_result_when_variant_is_absent_from_clinvar(
+        tmp_path,
+):
+    """
+    Verify that a detected candidate absent from the local ClinVar database
+    produces no annotation and does not fail the confirmation workflow.
+    """
+    clinvar_db = tmp_path / "clinvar_database_GRCh38.txt"
+    submission_db = tmp_path / "clinvar_submission.txt.gz"
+
+    _write_clinvar_database(clinvar_db)
+    _write_submission_database(submission_db)
+
+    annotations = VariantConfirmationClinVarLookup().lookup(
+        matches=[
+            _build_match(
+                position=123456,
+            )
+        ],
+        clinvar_db=clinvar_db,
+        clinvar_submission_db=submission_db,
+    )
+
+    assert annotations == {}


### PR DESCRIPTION
## Summary
This PR extends the Variant Confirmation workflow by retrieving ClinVar information directly from the local ClinVar database instead of relying on the ClinVar fields returned by GeneBe.

GeneBe remains responsible for gene/transcript annotation and ACMG classification, while ClinVar becomes the authoritative source for clinical significance and disease-related information.

This change improves consistency with the existing PR/RR workflows and ensures that Variant Confirmation always reports the same ClinVar information available in the local SFtool database.

## Related Issue
Refs #48 

## Type of change
- [X] Feature (feat)
- [ ] Bug fix (fix)
- [X] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [X] Tests
- [ ] Maintenance / Chore

## Checklist
- [ ] Code compiles and runs
- [X] Tests added or updated
- [ ] Documentation updated
- [X] Linked the related issue (e.g., "Refs #48")
