### PR TITLE
Resource Management Workflow: Phase 2 — Catalog preparation

### DIFF
--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -3,7 +3,10 @@ Implementation of ``sftool resources setup``.
 """
 
 from pathlib import Path
-from sftool.utils.resource_utils import load_bundled_resources
+from sftool.utils.resource_utils import (
+    load_bundled_resources,
+    ResourceOperationError,
+)
 from sftool.utils.catalog_utils import (
     CatalogGenerationError,
     prepare_catalog_resources,
@@ -117,7 +120,28 @@ def setup(
         catalog_resources = prepare_catalog_resources(
             output_root=output_dir,
         )
-    except CatalogGenerationError as error:
+    except (
+            CatalogGenerationError,
+            ResourceOperationError,
+    ) as error:
         raise click.ClickException(str(error)) from error
+
+    for assembly, catalogs in (
+            catalog_resources["assemblies"].items()
+    ):
+        click.echo(f"  {assembly}")
+
+    for category, resources in catalogs.items():
+        click.echo(
+            f"    {category}: "
+            f"{resources['bed']}, "
+            f"{resources['chr_bed']}, "
+            f"{resources['json']}"
+        )
+
+    click.echo(
+        "  RR_STR: "
+        f"{catalog_resources['RR_STR']['csv']}"
+    )
 
     click.echo("Catalog resources prepared successfully.")

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -4,6 +4,10 @@ Implementation of ``sftool resources setup``.
 
 from pathlib import Path
 from sftool.utils.resource_utils import load_bundled_resources
+from sftool.utils.catalog_utils import (
+    CatalogGenerationError,
+    prepare_catalog_resources,
+)
 
 import click
 
@@ -84,8 +88,12 @@ def setup(
 
     resource_version = resource_version.lower()
 
-    if resource_version == "bundled":
-        bundled_resources = load_bundled_resources()
+    if resource_version != "bundled":
+        raise click.ClickException(
+            f"Unsupported resource version: {resource_version}"
+        )
+
+    bundled_resources = load_bundled_resources()
 
     click.echo(
         "Bundled resource specification loaded "
@@ -103,7 +111,13 @@ def setup(
     )
 
     click.echo()
-    click.echo(
-        "Resource preparation is not implemented yet.",
-        err=True,
-    )
+    click.echo("Preparing catalog resources...")
+
+    try:
+        catalog_resources = prepare_catalog_resources(
+            output_root=output_dir,
+        )
+    except CatalogGenerationError as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo("Catalog resources prepared successfully.")

--- a/sftool/utils/catalog_utils.py
+++ b/sftool/utils/catalog_utils.py
@@ -6,167 +6,422 @@ Created on Tue Aug  8 19:07:52 2023
 @author: Javier Perez Florido, Edurne Urrutia
 """
 import csv
-import json
+from pathlib import Path
+import shutil
 from natsort import natsorted
 import requests
-import vcfpy
+from typing import NamedTuple
+from importlib.resources import as_file
+from sftool.utils.resource_utils import (
+    ensure_directory,
+    write_json,
+)
 
-def read_csv(in_csv, category):
-    """
-    Read a CSV file and store information in a dictionary
+GENERATED_CATALOGS = ("PR", "RR")
 
-    Args:
-        in_csv (str): Path to CSV file
+CATALOG_DESCRIPTIONS = {
+    "PR": "Secondary findings of personal risk",
+    "RR": "Secondary findings of reproductive risk",
+}
 
-    Returns:
-        dict, list: A dictionary with information from CSV file and a list of gene symbol
-    """
-    # Create dictionary and gene list to store info
-    if category == 'PR':
-        cat_str = 'personal'
-    elif category == 'RR':
-        cat_str = 'reproductive'
-    genes_dct = {
-        "category": f"Secondary findings of {cat_str} risk",
-        "genes": []
+GRCH37_GENE_ALIASES = {
+    "MMUT": "MUT",
+    "ELP1": "IKBKAP",
+    "G6PC1": "G6PC",
+    "GBA1": "GBA",
+}
+
+ENSEMBL_SERVERS = {
+    "GRCh37": "https://grch37.rest.ensembl.org",
+    "GRCh38": "https://rest.ensembl.org",
+}
+
+CATALOG_SOURCE_FILES = {
+    "PR": (
+        "PR",
+        "PR_risk_genes_ACMG_SF_v3.1.csv",
+    ),
+    "RR": (
+        "RR",
+        "RR_risk_genes_ACMG_CS_v2021.csv",
+    ),
+    "RR_STR": (
+        "RR",
+        "RR_risk_genes_STR_ACMG_CS_v2021.csv",
+    ),
+}
+
+class CatalogGenerationError(RuntimeError):
+    """Raised when an SFtool catalog cannot be generated."""
+class GeneCoordinate(NamedTuple):
+    chromosome: str
+    start: int
+    end: int
+    gene_symbol: str
+
+def read_catalog_csv(
+        source_csv: Path,
+        category: str,
+) -> tuple[dict, list[str]]:
+    try:
+        description = CATALOG_DESCRIPTIONS[category]
+    except KeyError as error:
+        raise CatalogGenerationError(
+            f"Unsupported generated catalog: {category}"
+        ) from error
+
+    catalog = {
+        "category": description,
+        "genes": [],
     }
 
-    genes_lst = []
-
-    # Read CSV file and store it in the dictionary
-    with open(in_csv, 'r', encoding='latin1') as file:
-        csv_reader = csv.DictReader(file)
-        for row in csv_reader:
-            gene_symbol = row['Gene']
-            gene_info = {
-                'gene_symbol': row['Gene'],
-                'phenotype': row['Phenotype'],
-                'ACMG_version': row.get('ACMG SF List Version', '') ,
-                'OMIM_disorder': row['OMIM Disorder'],
-                'inheritance': row['Inheritance'],
-                'variants_to_report': row.get('Variants to Report', ''),
-                'specific_variant_GRCh38': row.get('Specific variant GRCh38', ''),
-                'specific_variant_GRCh37': row.get('Specific variant GRCh37', ''),
-                'specific_consequence': row.get('Specific consequence', ''),
-            }
-            genes_dct["genes"].append(gene_info)
-            genes_lst.append(gene_symbol)
-
-    return(genes_dct, genes_lst)
-
-
-def get_gene_location_ensembl(gene_symbol, assembly):
-    """Fetch chromosome location of a gene from Ensembl REST API."""
-
-    # Define the Ensembl server based on genome version
-    if assembly == "GRCh37":
-        server = "https://grch37.rest.ensembl.org"  # GRCh37 (hg19) Ensembl server
-    elif assembly == "GRCh38":
-        server = "https://rest.ensembl.org"  # GRCh38 (hg38) Ensembl server
-
-    url = f"{server}/lookup/symbol/human/{gene_symbol}?content-type=application/json"
-
-    response = requests.get(url)
-
-    if response.status_code != 200:
-        return f"Error fetching data for {gene_symbol} ({assembly}): {response.status_code}"
-
-    data = response.json()
-
-    result = {}
-
-    result['Gene_symbol'] = gene_symbol
-    result['Chromosome'] = data['seq_region_name']
-    result['Start'] = data['start']
-    result['End'] = data['end']
-
-    return result
-
-
-def write_bed_file(assembly, genes_lst, bed_file, has_chr_prefix):
-    """
-    Write gene information to a BED format file
-
-    Args:
-        assembly (str): reference genome version ("GRCh37" or "GRCh38").
-        genes_lst (list): Gene symbol list
-        bed_file (str): Path to BED file to be generated
-        has_chr_prefix (boolean): Whether VCF file has chr prefix for CHROM value
-
-    Returns:
-        None
-    """
-
-    chr_prefix = ''
-    if has_chr_prefix:
-        chr_prefix = 'chr'
-
-
-    gene_coords = []
-    # Some genes change name between assemblies
-
-    for gene in genes_lst:
-        gene_query = gene
-        if gene == 'MMUT' and assembly == 'GRCh37':
-            gene_query = 'MUT'
-        elif gene == 'ELP1' and assembly == 'GRCh37':
-            gene_query = 'IKBKAP'
-        elif gene == 'G6PC1' and assembly == 'GRCh37':
-            gene_query = 'G6PC'
-        elif gene == 'GBA1' and assembly == 'GRCh37':
-            gene_query = 'GBA'
-
-        gene_pos = get_gene_location_ensembl(gene_query, assembly)
-
-        gene_coords.append((gene_pos['Chromosome'], int(gene_pos['Start']), int(gene_pos['End']), gene))
-    sorted_coords = natsorted(gene_coords)
-
-    with open(bed_file, "w") as fdw:
-        for chrom, start, end, gene in sorted_coords:
-            fdw.write(f"{chr_prefix}{chrom}\t{start}\t{end}\t{gene}\n")
-        print(f"BED file '{bed_file}' generated successfully.")
-
-def has_chr_prefix_vcf(vcf_file):
-    reader = vcfpy.Reader.from_path(vcf_file)
-    for record in reader:
-        return record.CHROM.startswith("chr")  # Check first variant
-    return False  # If no variants are found
-
-
-def build_catalog_resources(category, assembly, category_geneset_file, bed_file, json_file, vcf_file):
-    """
-    Main function: from a CSV file, creates a JSON and a BED files
-
-    Args:
-        category (str): category, either PR or RR
-        assembly (str): assembly version ("GRCh37" or "GRCh38").
-        category_geneset_file (str): Path to CSV file for the given category
-        bed_file (str): Path to BED file to be generated
-        json_file (str): Path to JSON file to be generated
-        vcf_file (str): Path to original VCF file
-
-    Returns:
-        None
-    """
-
-    print("Creating BED and JSON files for " + category + " catalogue.")
+    genes: list[str] = []
 
     try:
+        with source_csv.open(
+                "r",
+                encoding="latin1",
+                newline="",
+        ) as handle:
+            reader = csv.DictReader(handle)
 
-        # Check whether chr prefix is used in VCF file
-        has_chr_prefix = has_chr_prefix_vcf(vcf_file)
+            if not reader.fieldnames or "Gene" not in reader.fieldnames:
+                raise CatalogGenerationError(
+                    f"Catalog CSV does not contain a 'Gene' column: "
+                    f"{source_csv}"
+                )
 
-        # Read CSV and store it in the dictionary
-        genes_dct, genes_lst = read_csv(category_geneset_file, category)
+            for row in reader:
+                gene_symbol = row["Gene"].strip()
 
-        # Write a BED file
-        write_bed_file(assembly, genes_lst, bed_file, has_chr_prefix)
+                if not gene_symbol:
+                    raise CatalogGenerationError(
+                        f"Empty gene symbol found in {source_csv}"
+                    )
 
-        # Write a JSON file
-        with open(json_file, 'w') as fdw:
-            json.dump(genes_dct, fdw, indent = 4)
-            print(f"JSON file '{json_file}' generated successfully.")
+                catalog["genes"].append(
+                    {
+                        "gene_symbol": gene_symbol,
+                        "phenotype": row.get("Phenotype", ""),
+                        "ACMG_version": row.get(
+                            "ACMG SF List Version",
+                            "",
+                        ),
+                        "OMIM_disorder": row.get(
+                            "OMIM Disorder",
+                            "",
+                        ),
+                        "inheritance": row.get(
+                            "Inheritance",
+                            "",
+                        ),
+                        "variants_to_report": row.get(
+                            "Variants to Report",
+                            "",
+                        ),
+                        "specific_variant_GRCh38": row.get(
+                            "Specific variant GRCh38",
+                            "",
+                        ),
+                        "specific_variant_GRCh37": row.get(
+                            "Specific variant GRCh37",
+                            "",
+                        ),
+                        "specific_consequence": row.get(
+                            "Specific consequence",
+                            "",
+                        ),
+                    }
+                )
+
+                genes.append(gene_symbol)
+
+    except OSError as error:
+        raise CatalogGenerationError(
+            f"Could not read catalog CSV: {source_csv}"
+        ) from error
+
+    return catalog, genes
 
 
-    except Exception as e:
-        print(f"An error occurred: {str(e)}")
+def get_gene_location_ensembl(
+        gene_symbol: str,
+        assembly: str,
+        *,
+        timeout: float = 30.0,
+) -> dict[str, object]:
+    try:
+        server = ENSEMBL_SERVERS[assembly]
+    except KeyError as error:
+        raise CatalogGenerationError(
+            f"Unsupported genome assembly: {assembly}"
+        ) from error
+
+    url = (
+        f"{server}/lookup/symbol/human/{gene_symbol}"
+        "?content-type=application/json"
+    )
+
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as error:
+        raise CatalogGenerationError(
+            f"Could not retrieve coordinates for gene "
+            f"{gene_symbol!r} using {assembly}"
+        ) from error
+    except ValueError as error:
+        raise CatalogGenerationError(
+            f"Invalid JSON returned by Ensembl for gene "
+            f"{gene_symbol!r} using {assembly}"
+        ) from error
+
+    required_fields = {
+        "seq_region_name",
+        "start",
+        "end",
+    }
+
+    if not isinstance(data, dict) or not required_fields.issubset(data):
+        raise CatalogGenerationError(
+            f"Incomplete Ensembl response for gene "
+            f"{gene_symbol!r} using {assembly}"
+        )
+
+    return {
+        "Gene_symbol": gene_symbol,
+        "Chromosome": data["seq_region_name"],
+        "Start": data["start"],
+        "End": data["end"],
+    }
+
+def collect_gene_coordinates(
+        genes: list[str],
+        assembly: str,
+) -> list[GeneCoordinate]:
+    coordinates: list[GeneCoordinate] = []
+
+    for gene_symbol in genes:
+        query_symbol = gene_symbol
+
+        if assembly == "GRCh37":
+            query_symbol = GRCH37_GENE_ALIASES.get(
+                gene_symbol,
+                gene_symbol,
+            )
+
+        location = get_gene_location_ensembl(
+            query_symbol,
+            assembly,
+        )
+
+        coordinates.append(
+            GeneCoordinate(
+                chromosome=str(location["Chromosome"]),
+                start=int(location["Start"]),
+                end=int(location["End"]),
+                gene_symbol=gene_symbol,
+            )
+        )
+
+    return natsorted(
+        coordinates,
+        key=lambda coordinate: (
+            coordinate.chromosome,
+            coordinate.start,
+            coordinate.end,
+            coordinate.gene_symbol,
+        ),
+    )
+
+def format_chromosome(
+        chromosome: str,
+        *,
+        chr_prefix: bool,
+) -> str:
+    if not chr_prefix:
+        return chromosome
+
+    if chromosome == "MT":
+        return "chrM"
+
+    return f"chr{chromosome}"
+
+def write_bed_file(
+        coordinates: list[GeneCoordinate],
+        destination: Path,
+        *,
+        chr_prefix: bool,
+) -> Path:
+    ensure_directory(destination.parent)
+
+    try:
+        with destination.open(
+                "w",
+                encoding="utf-8",
+        ) as handle:
+            for coordinate in coordinates:
+                chromosome = format_chromosome(
+                    coordinate.chromosome,
+                    chr_prefix=chr_prefix,
+                )
+
+                handle.write(
+                    f"{chromosome}\t"
+                    f"{coordinate.start}\t"
+                    f"{coordinate.end}\t"
+                    f"{coordinate.gene_symbol}\n"
+                )
+    except OSError as error:
+        raise CatalogGenerationError(
+            f"Could not write BED file: {destination}"
+        ) from error
+
+    return destination
+
+
+def get_bundled_catalog_resource(category: str):
+    try:
+        subdirectory, filename = CATALOG_SOURCE_FILES[category]
+    except KeyError as error:
+        raise CatalogGenerationError(
+            f"Unsupported catalog: {category}"
+        ) from error
+
+    return (
+        files("sftool.data.categories")
+        .joinpath(subdirectory)
+        .joinpath(filename)
+    )
+
+def copy_rr_str_catalog(
+        output_root: Path,
+        *,
+        overwrite: bool = False,
+) -> Path:
+    source_resource = get_bundled_catalog_resource(
+        "RR_STR"
+    )
+
+    destination_dir = ensure_directory(
+        output_root / "catalogs" / "RR_STR"
+    )
+
+    destination = (
+            destination_dir
+            / "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    )
+
+    try:
+        with as_file(source_resource) as source_path:
+            shutil.copy2(
+                source_path,
+                destination,
+            )
+    except OSError as error:
+        raise CatalogGenerationError(
+            f"Could not copy RR_STR catalog to {destination}"
+        ) from error
+
+    return destination
+
+def build_catalog_resources(
+        category: str,
+        assembly: str,
+        source_csv: Path,
+        output_dir: Path,
+) -> dict[str, Path]:
+    if category not in GENERATED_CATALOGS:
+        raise CatalogGenerationError(
+            f"Catalog {category!r} cannot be generated as BED/JSON"
+        )
+
+    if assembly not in ENSEMBL_SERVERS:
+        raise CatalogGenerationError(
+            f"Unsupported genome assembly: {assembly}"
+        )
+
+    output_dir = ensure_directory(output_dir)
+
+    catalog_data, genes = read_catalog_csv(
+        source_csv,
+        category,
+    )
+
+    coordinates = collect_gene_coordinates(
+        genes,
+        assembly,
+    )
+
+    bed_path = output_dir / f"{category}.bed"
+    chr_bed_path = output_dir / f"{category}.chr.bed"
+    json_path = output_dir / f"{category}.json"
+
+    write_bed_file(
+        coordinates,
+        bed_path,
+        chr_prefix=False,
+    )
+
+    write_bed_file(
+        coordinates,
+        chr_bed_path,
+        chr_prefix=True,
+    )
+
+    write_json(
+        catalog_data,
+        json_path,
+    )
+
+    return {
+        "bed": bed_path,
+        "chr_bed": chr_bed_path,
+        "json": json_path,
+    }
+
+def prepare_catalog_resources(
+        output_root: Path,
+) -> dict[str, object]:
+    output_root = ensure_directory(output_root)
+
+    generated_catalogs: dict[str, object] = {
+        "assemblies": {},
+        "RR_STR": {},
+    }
+
+    for assembly in ("GRCh37", "GRCh38"):
+        assembly_output_dir = ensure_directory(
+            output_root / "catalogs" / assembly
+        )
+
+        generated_catalogs["assemblies"][assembly] = {}
+
+        for category in GENERATED_CATALOGS:
+            source_resource = get_bundled_catalog_resource(
+                category
+            )
+
+            with as_file(source_resource) as source_csv:
+                outputs = build_catalog_resources(
+                    category=category,
+                    assembly=assembly,
+                    source_csv=source_csv,
+                    output_dir=assembly_output_dir,
+                )
+
+            generated_catalogs["assemblies"][assembly][
+                category
+            ] = {
+                name: str(path)
+                for name, path in outputs.items()
+            }
+
+    rr_str_path = copy_rr_str_catalog(output_root)
+
+    generated_catalogs["RR_STR"] = {
+        "csv": str(rr_str_path),
+    }
+
+    return generated_catalogs

--- a/sftool/utils/catalog_utils.py
+++ b/sftool/utils/catalog_utils.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import shutil
 from natsort import natsorted
 import requests
+from collections.abc import Sequence
 from typing import NamedTuple
 from importlib.resources import as_file
 from sftool.utils.resource_utils import (
@@ -240,16 +241,18 @@ def format_chromosome(
         *,
         chr_prefix: bool,
 ) -> str:
-    if not chr_prefix:
-        return chromosome
+    chromosome = chromosome.strip()
 
-    if chromosome == "MT":
-        return "chrM"
+    if chromosome.startswith("chr"):
+        chromosome = chromosome[3:]
 
-    return f"chr{chromosome}"
+    if chromosome in {"M", "MT"}:
+        return "chrM" if chr_prefix else "MT"
+
+    return f"chr{chromosome}" if chr_prefix else chromosome
 
 def write_bed_file(
-        coordinates: list[GeneCoordinate],
+        coordinates: Sequence[GeneCoordinate],
         destination: Path,
         *,
         chr_prefix: bool,
@@ -260,6 +263,7 @@ def write_bed_file(
         with destination.open(
                 "w",
                 encoding="utf-8",
+                newline="",
         ) as handle:
             for coordinate in coordinates:
                 chromosome = format_chromosome(
@@ -326,6 +330,37 @@ def copy_rr_str_catalog(
 
     return destination
 
+def write_bed_variants(
+        coordinates: list[GeneCoordinate],
+        output_dir: Path,
+        category: str,
+) -> dict[str, Path]:
+    """
+    Write both BED chromosome conventions for one catalog.
+
+    Returns paths for:
+    - standard chromosome names: 1, 2, X, Y, MT
+    - chr-prefixed names: chr1, chr2, chrX, chrY, chrM
+    """
+    bed_path = output_dir / f"{category}.bed"
+    chr_bed_path = output_dir / f"{category}.chr.bed"
+
+    write_bed_file(
+        coordinates=coordinates,
+        destination=bed_path,
+        chr_prefix=False,
+    )
+
+    write_bed_file(
+        coordinates=coordinates,
+        destination=chr_bed_path,
+        chr_prefix=True,
+    )
+
+    return {
+        "bed": bed_path,
+        "chr_bed": chr_bed_path,
+    }
 def build_catalog_resources(
         category: str,
         assembly: str,
@@ -354,21 +389,13 @@ def build_catalog_resources(
         assembly,
     )
 
-    bed_path = output_dir / f"{category}.bed"
-    chr_bed_path = output_dir / f"{category}.chr.bed"
+    bed_outputs = write_bed_variants(
+        coordinates=coordinates,
+        output_dir=output_dir,
+        category=category,
+    )
+
     json_path = output_dir / f"{category}.json"
-
-    write_bed_file(
-        coordinates,
-        bed_path,
-        chr_prefix=False,
-    )
-
-    write_bed_file(
-        coordinates,
-        chr_bed_path,
-        chr_prefix=True,
-    )
 
     write_json(
         catalog_data,
@@ -376,8 +403,7 @@ def build_catalog_resources(
     )
 
     return {
-        "bed": bed_path,
-        "chr_bed": chr_bed_path,
+        **bed_outputs,
         "json": json_path,
     }
 

--- a/sftool/utils/catalog_utils.py
+++ b/sftool/utils/catalog_utils.py
@@ -12,7 +12,7 @@ from natsort import natsorted
 import requests
 from collections.abc import Sequence
 from typing import NamedTuple
-from importlib.resources import as_file
+from importlib.resources import as_file, files
 from sftool.utils.resource_utils import (
     ensure_directory,
     write_json,
@@ -252,15 +252,17 @@ def format_chromosome(
     return f"chr{chromosome}" if chr_prefix else chromosome
 
 def write_bed_file(
-        coordinates: Sequence[GeneCoordinate],
+        coordinates: list[GeneCoordinate],
         destination: Path,
         *,
         chr_prefix: bool,
 ) -> Path:
-    ensure_directory(destination.parent)
+    temporary_path = destination.with_name(
+        f"{destination.name}.tmp"
+    )
 
     try:
-        with destination.open(
+        with temporary_path.open(
                 "w",
                 encoding="utf-8",
                 newline="",
@@ -277,7 +279,12 @@ def write_bed_file(
                     f"{coordinate.end}\t"
                     f"{coordinate.gene_symbol}\n"
                 )
+
+        temporary_path.replace(destination)
+
     except OSError as error:
+        temporary_path.unlink(missing_ok=True)
+
         raise CatalogGenerationError(
             f"Could not write BED file: {destination}"
         ) from error
@@ -422,7 +429,7 @@ def prepare_catalog_resources(
             output_root / "catalogs" / assembly
         )
 
-        generated_catalogs["assemblies"][assembly] = {}
+        assembly_catalogs: dict[str, dict[str, str]] = {}
 
         for category in GENERATED_CATALOGS:
             source_resource = get_bundled_catalog_resource(
@@ -437,14 +444,18 @@ def prepare_catalog_resources(
                     output_dir=assembly_output_dir,
                 )
 
-            generated_catalogs["assemblies"][assembly][
-                category
-            ] = {
+            assembly_catalogs[category] = {
                 name: str(path)
                 for name, path in outputs.items()
             }
 
-    rr_str_path = copy_rr_str_catalog(output_root)
+        generated_catalogs["assemblies"][assembly] = (
+            assembly_catalogs
+        )
+
+    rr_str_path = copy_rr_str_catalog(
+        output_root
+    )
 
     generated_catalogs["RR_STR"] = {
         "csv": str(rr_str_path),

--- a/tests/utils/test_catalog_utils.py
+++ b/tests/utils/test_catalog_utils.py
@@ -11,6 +11,7 @@ from sftool.utils.catalog_utils import (
     collect_gene_coordinates,
     copy_rr_str_catalog,
     write_bed_file,
+    format_chromosome,
 )
 
 
@@ -116,3 +117,111 @@ def test_copy_rr_str_catalog_preserves_file(tmp_path, monkeypatch):
     )
 
     assert destination.read_bytes() == source.read_bytes()
+
+@pytest.mark.parametrize(
+    ("chromosome", "plain", "prefixed"),
+    [
+        ("1", "1", "chr1"),
+        ("X", "X", "chrX"),
+        ("MT", "MT", "chrM"),
+        ("chr1", "1", "chr1"),
+        ("chrM", "MT", "chrM"),
+    ],
+)
+def test_format_chromosome(chromosome, plain, prefixed):
+    assert format_chromosome(
+        chromosome,
+        chr_prefix=False,
+    ) == plain
+
+    assert format_chromosome(
+        chromosome,
+        chr_prefix=True,
+    ) == prefixed
+
+
+def test_build_catalog_resources_generates_both_bed_conventions(
+        tmp_path,
+        monkeypatch,
+):
+    source_csv = tmp_path / "PR.csv"
+    source_csv.write_text(
+        "Gene,Phenotype\nGENE1,Condition\n",
+        encoding="latin1",
+    )
+
+    coordinate_lookup = Mock(
+        return_value=[
+            GeneCoordinate("1", 10, 20, "GENE1"),
+            GeneCoordinate("MT", 30, 40, "GENE2"),
+        ]
+    )
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "collect_gene_coordinates",
+        coordinate_lookup,
+    )
+
+    outputs = build_catalog_resources(
+        category="PR",
+        assembly="GRCh38",
+        source_csv=source_csv,
+        output_dir=tmp_path,
+    )
+
+    assert outputs["bed"].read_text() == (
+        "1\t10\t20\tGENE1\n"
+        "MT\t30\t40\tGENE2\n"
+    )
+
+    assert outputs["chr_bed"].read_text() == (
+        "chr1\t10\t20\tGENE1\n"
+        "chrM\t30\t40\tGENE2\n"
+    )
+
+    coordinate_lookup.assert_called_once_with(
+        ["GENE1"],
+        "GRCh38",
+    )
+
+
+def test_bed_conventions_preserve_coordinates_and_gene_order(
+        tmp_path,
+        monkeypatch,
+):
+    source_csv = tmp_path / "RR.csv"
+    source_csv.write_text(
+        "Gene\nGENE1\n",
+        encoding="latin1",
+    )
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "collect_gene_coordinates",
+        Mock(
+            return_value=[
+                GeneCoordinate("2", 100, 200, "GENE1"),
+            ]
+        ),
+    )
+
+    outputs = build_catalog_resources(
+        category="RR",
+        assembly="GRCh37",
+        source_csv=source_csv,
+        output_dir=tmp_path,
+    )
+
+    plain_rows = [
+        line.split("\t")
+        for line in outputs["bed"].read_text().splitlines()
+    ]
+    prefixed_rows = [
+        line.split("\t")
+        for line in outputs["chr_bed"].read_text().splitlines()
+    ]
+
+    assert [row[1:] for row in plain_rows] == [
+        row[1:] for row in prefixed_rows
+    ]

--- a/tests/utils/test_catalog_utils.py
+++ b/tests/utils/test_catalog_utils.py
@@ -12,6 +12,7 @@ from sftool.utils.catalog_utils import (
     copy_rr_str_catalog,
     write_bed_file,
     format_chromosome,
+    prepare_catalog_resources,
 )
 
 
@@ -59,6 +60,48 @@ def test_write_bed_file_generates_both_chromosome_styles(tmp_path):
         "chrM\t30\t40\tGENE2\n"
     )
 
+def test_write_bed_file_removes_temporary_file_on_error(
+        tmp_path,
+        monkeypatch,
+):
+    coordinates = [
+        GeneCoordinate(
+            "1",
+            10,
+            20,
+            "GENE1",
+        )
+    ]
+
+    destination = tmp_path / "PR.bed"
+    temporary_path = tmp_path / "PR.bed.tmp"
+
+    original_replace = Path.replace
+
+    def failing_replace(self, target):
+        if self == temporary_path:
+            raise OSError("Simulated replace failure")
+
+        return original_replace(self, target)
+
+    monkeypatch.setattr(
+        Path,
+        "replace",
+        failing_replace,
+    )
+
+    with pytest.raises(
+            CatalogGenerationError,
+            match="Could not write BED file",
+    ):
+        write_bed_file(
+            coordinates,
+            destination,
+            chr_prefix=False,
+        )
+
+    assert not temporary_path.exists()
+    assert not destination.exists()
 
 def test_build_catalog_resources_creates_expected_files(
         tmp_path,
@@ -103,7 +146,10 @@ def test_build_catalog_resources_rejects_rr_str(tmp_path):
 
 
 def test_copy_rr_str_catalog_preserves_file(tmp_path, monkeypatch):
-    source = tmp_path / "RR_STR.csv"
+    source = (
+            tmp_path
+            / "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    )
     source.write_text("Gene\nFMR1\n", encoding="latin1")
 
     monkeypatch.setattr(
@@ -117,6 +163,44 @@ def test_copy_rr_str_catalog_preserves_file(tmp_path, monkeypatch):
     )
 
     assert destination.read_bytes() == source.read_bytes()
+
+    assert destination.name == (
+        "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    )
+    assert destination.parent.name == "RR_STR"
+    assert destination.parent.parent.name == "catalogs"
+
+
+def test_copy_rr_str_catalog_only_creates_csv(
+        tmp_path,
+        monkeypatch,
+):
+    source = tmp_path / "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    source.write_text(
+        "Gene\nFMR1\n",
+        encoding="latin1",
+    )
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "get_bundled_catalog_resource",
+        lambda category: source,
+    )
+
+    output_root = tmp_path / "resources"
+
+    destination = copy_rr_str_catalog(output_root)
+
+    rr_str_directory = output_root / "catalogs" / "RR_STR"
+
+    assert destination == (
+            rr_str_directory
+            / "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    )
+    assert destination.exists()
+
+    assert list(rr_str_directory.glob("*.bed")) == []
+    assert list(rr_str_directory.glob("*.json")) == []
 
 @pytest.mark.parametrize(
     ("chromosome", "plain", "prefixed"),
@@ -225,3 +309,123 @@ def test_bed_conventions_preserve_coordinates_and_gene_order(
     assert [row[1:] for row in plain_rows] == [
         row[1:] for row in prefixed_rows
     ]
+
+def test_prepare_catalog_resources_creates_expected_structure(
+        tmp_path,
+        monkeypatch,
+):
+    pr_source = tmp_path / "PR.csv"
+    pr_source.write_text(
+        "Gene,Phenotype\nGENE1,Condition 1\n",
+        encoding="latin1",
+    )
+
+    rr_source = tmp_path / "RR.csv"
+    rr_source.write_text(
+        "Gene,Phenotype\nGENE2,Condition 2\n",
+        encoding="latin1",
+    )
+
+    rr_str_source = (
+            tmp_path
+            / "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    )
+    rr_str_source.write_text(
+        "Gene\nFMR1\n",
+        encoding="latin1",
+    )
+
+    sources = {
+        "PR": pr_source,
+        "RR": rr_source,
+        "RR_STR": rr_str_source,
+    }
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "get_bundled_catalog_resource",
+        lambda category: sources[category],
+    )
+
+    def fake_collect_gene_coordinates(
+            genes,
+            assembly,
+    ):
+        chromosome = "1" if assembly == "GRCh37" else "2"
+
+        return [
+            GeneCoordinate(
+                chromosome,
+                10,
+                20,
+                gene,
+            )
+            for gene in genes
+        ]
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "collect_gene_coordinates",
+        fake_collect_gene_coordinates,
+    )
+
+    output_root = tmp_path / "resources"
+
+    resources = prepare_catalog_resources(
+        output_root=output_root,
+    )
+
+    expected_generated_files = [
+        output_root / "catalogs/GRCh37/PR.bed",
+        output_root / "catalogs/GRCh37/PR.chr.bed",
+        output_root / "catalogs/GRCh37/PR.json",
+        output_root / "catalogs/GRCh37/RR.bed",
+        output_root / "catalogs/GRCh37/RR.chr.bed",
+        output_root / "catalogs/GRCh37/RR.json",
+        output_root / "catalogs/GRCh38/PR.bed",
+        output_root / "catalogs/GRCh38/PR.chr.bed",
+        output_root / "catalogs/GRCh38/PR.json",
+        output_root / "catalogs/GRCh38/RR.bed",
+        output_root / "catalogs/GRCh38/RR.chr.bed",
+        output_root / "catalogs/GRCh38/RR.json",
+        ]
+
+    for expected_file in expected_generated_files:
+        assert expected_file.exists()
+
+    expected_rr_str = (
+            output_root
+            / "catalogs"
+            / "RR_STR"
+            / "RR_risk_genes_STR_ACMG_CS_v2021.csv"
+    )
+
+    assert expected_rr_str.exists()
+
+    assert not (
+            output_root / "catalogs/GRCh37/RR_STR.bed"
+    ).exists()
+    assert not (
+            output_root / "catalogs/GRCh37/RR_STR.json"
+    ).exists()
+    assert not (
+            output_root / "catalogs/GRCh38/RR_STR.bed"
+    ).exists()
+    assert not (
+            output_root / "catalogs/GRCh38/RR_STR.json"
+    ).exists()
+
+    assert set(resources["assemblies"]) == {
+        "GRCh37",
+        "GRCh38",
+    }
+
+    assert set(
+        resources["assemblies"]["GRCh37"]
+    ) == {"PR", "RR"}
+
+    assert set(
+        resources["assemblies"]["GRCh38"]
+    ) == {"PR", "RR"}
+
+    assert "csv" in resources["RR_STR"]

--- a/tests/utils/test_catalog_utils.py
+++ b/tests/utils/test_catalog_utils.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from sftool.utils import catalog_utils
+from sftool.utils.catalog_utils import (
+    CatalogGenerationError,
+    GeneCoordinate,
+    build_catalog_resources,
+    collect_gene_coordinates,
+    copy_rr_str_catalog,
+    write_bed_file,
+)
+
+
+def test_collect_gene_coordinates_uses_grch37_alias(monkeypatch):
+    lookup = Mock(
+        return_value={
+            "Chromosome": "6",
+            "Start": 100,
+            "End": 200,
+        }
+    )
+    monkeypatch.setattr(
+        catalog_utils,
+        "get_gene_location_ensembl",
+        lookup,
+    )
+
+    coordinates = collect_gene_coordinates(
+        ["MMUT"],
+        "GRCh37",
+    )
+
+    lookup.assert_called_once_with("MUT", "GRCh37")
+    assert coordinates[0].gene_symbol == "MMUT"
+
+
+def test_write_bed_file_generates_both_chromosome_styles(tmp_path):
+    coordinates = [
+        GeneCoordinate("1", 10, 20, "GENE1"),
+        GeneCoordinate("MT", 30, 40, "GENE2"),
+    ]
+
+    plain = tmp_path / "PR.bed"
+    prefixed = tmp_path / "PR.chr.bed"
+
+    write_bed_file(coordinates, plain, chr_prefix=False)
+    write_bed_file(coordinates, prefixed, chr_prefix=True)
+
+    assert plain.read_text() == (
+        "1\t10\t20\tGENE1\n"
+        "MT\t30\t40\tGENE2\n"
+    )
+    assert prefixed.read_text() == (
+        "chr1\t10\t20\tGENE1\n"
+        "chrM\t30\t40\tGENE2\n"
+    )
+
+
+def test_build_catalog_resources_creates_expected_files(
+        tmp_path,
+        monkeypatch,
+):
+    source_csv = tmp_path / "PR.csv"
+    source_csv.write_text(
+        "Gene,Phenotype\nGENE1,Condition\n",
+        encoding="latin1",
+    )
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "collect_gene_coordinates",
+        Mock(
+            return_value=[
+                GeneCoordinate("1", 10, 20, "GENE1")
+            ]
+        ),
+    )
+
+    outputs = build_catalog_resources(
+        category="PR",
+        assembly="GRCh38",
+        source_csv=source_csv,
+        output_dir=tmp_path / "catalogs",
+    )
+
+    assert outputs["bed"].exists()
+    assert outputs["chr_bed"].exists()
+    assert outputs["json"].exists()
+
+
+def test_build_catalog_resources_rejects_rr_str(tmp_path):
+    with pytest.raises(CatalogGenerationError):
+        build_catalog_resources(
+            category="RR_STR",
+            assembly="GRCh38",
+            source_csv=tmp_path / "RR_STR.csv",
+            output_dir=tmp_path / "catalogs",
+        )
+
+
+def test_copy_rr_str_catalog_preserves_file(tmp_path, monkeypatch):
+    source = tmp_path / "RR_STR.csv"
+    source.write_text("Gene\nFMR1\n", encoding="latin1")
+
+    monkeypatch.setattr(
+        catalog_utils,
+        "get_bundled_catalog_resource",
+        lambda category: source,
+    )
+
+    destination = copy_rr_str_catalog(
+        tmp_path / "resources"
+    )
+
+    assert destination.read_bytes() == source.read_bytes()


### PR DESCRIPTION
## Summary
This PR completes Phase 2 – Catalog preparation of the resource management workflow by implementing automatic generation of catalog resources during sftool resources setup. It generates PR and RR JSON and BED resources for both GRCh37 and GRCh38, supports both standard and chr-prefixed chromosome conventions, integrates Ensembl lookups with GRCh37 gene aliases, and copies the RR_STR catalog as a CSV without additional processing. The implementation also improves robustness through atomic BED writing, enhances CLI error handling, and adds comprehensive unit tests covering the catalog preparation workflow.

## Related Issue
Refs #58 

## Type of change
- [X] Feature (feat)
- [ ] Bug fix (fix)
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [X] Tests
- [ ] Maintenance / Chore

## Checklist
- [ ] Code compiles and runs
- [X] Tests added or updated
- [ ] Documentation updated
- [X] Linked the related issue (e.g., "Closes #58 ")
