### PR TITLE
Resource Management Workflow: Phase 3 — External datasets and installed manifest

### DIFF
--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -45,7 +45,6 @@ reference genomes.
 Example:
   sftool resources setup \\
     --output-dir /data/sftool_resources \\
-    --clinvar-evidence 1 \\
     --resource-version bundled \\
     --download-reference-genomes
 """

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -3,11 +3,6 @@ Implementation of ``sftool resources setup``.
 """
 
 from pathlib import Path
-from sftool.utils.resource_utils import (
-    load_bundled_resources,
-    ResourceOperationError,
-    ResourceSpecificationError,
-)
 from sftool.utils.catalog_utils import (
     CatalogGenerationError,
     prepare_catalog_resources,
@@ -23,6 +18,7 @@ from sftool.utils.resource_utils import (
     load_bundled_resources,
     ResourceOperationError,
     ResourceSpecificationError,
+    download_versioned_resource
 )
 
 import click
@@ -212,3 +208,43 @@ def setup(
     )
 
     click.echo("Catalog resources prepared successfully.")
+
+    click.echo()
+    click.echo("Downloading HPO resource...")
+
+    try:
+        hpo_resource = download_versioned_resource(
+            output_root=output_dir,
+            resource_name="hpo",
+            specification=bundled_resources["hpo"],
+            validator=validate_hpo_gene_to_phenotype,
+        )
+    except (
+            ResourceOperationError,
+            ResourceSpecificationError,
+    ) as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(f"  Version: {hpo_resource['version']}")
+    click.echo(f"  File: {hpo_resource['path']}")
+    click.echo("HPO resource downloaded successfully.")
+
+    click.echo()
+    click.echo("Downloading PharmCAT positions resource...")
+
+    try:
+        pharmcat_resource = download_versioned_resource(
+            output_root=output_dir,
+            resource_name="pharmcat",
+            specification=bundled_resources["pharmcat"],
+            validator=validate_vcf_resource,
+        )
+    except (
+            ResourceOperationError,
+            ResourceSpecificationError,
+    ) as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(f"  Version: {pharmcat_resource['version']}")
+    click.echo(f"  File: {pharmcat_resource['path']}")
+    click.echo("PharmCAT positions resource downloaded successfully.")

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from sftool.utils.resource_utils import (
     load_bundled_resources,
     ResourceOperationError,
+    ResourceSpecificationError,
 )
 from sftool.utils.catalog_utils import (
     CatalogGenerationError,
@@ -13,6 +14,8 @@ from sftool.utils.catalog_utils import (
 )
 
 from sftool.utils.clinvar_utils import (
+    ClinVarProcessingError,
+    build_clinvar_databases,
     download_bundled_clinvar_snapshot,
 )
 
@@ -59,7 +62,7 @@ Example:
 )
 @click.option(
     "--clinvar-evidence",
-    type=click.IntRange(min=1, max=5),
+    type=click.IntRange(min=1, max=4),
     default=1,
     show_default=True,
     help=(
@@ -152,6 +155,30 @@ def setup(
     click.echo(
         "ClinVar source snapshot downloaded successfully."
     )
+
+    click.echo()
+    click.echo("Generating ClinVar assembly databases...")
+
+    try:
+        clinvar_databases = build_clinvar_databases(
+            variant_summary_path=Path(
+                clinvar_resources["variant_summary"]
+            ),
+            output_root=output_dir,
+            version=clinvar_resources["version"],
+        )
+    except ClinVarProcessingError as error:
+        raise click.ClickException(str(error)) from error
+
+    for assembly, database_path in clinvar_databases.items():
+        click.echo(
+            f"  {assembly}: {database_path}"
+        )
+
+    click.echo(
+        "ClinVar assembly databases generated successfully."
+    )
+
 
     click.echo()
     click.echo("Preparing catalog resources...")

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -322,7 +322,7 @@ def setup(
     click.echo("Writing installed resource manifest...")
 
     try:
-        manifest = build_installed_manifest(
+        manifest_path = write_installed_manifest(
             output_root=output_dir,
             resource_version=resource_version,
             catalog_resources=catalog_resources,
@@ -334,10 +334,6 @@ def setup(
             reference_resources=reference_resources,
         )
 
-        manifest_path = write_installed_manifest(
-            output_root=output_dir,
-            manifest=manifest,
-        )
     except ResourceOperationError as error:
         raise click.ClickException(str(error)) from error
 

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -26,6 +26,11 @@ from sftool.utils.resource_utils import (
     validate_vcf_resource
 )
 
+from sftool.utils.manifest_utils import (
+    build_installed_manifest,
+    write_installed_manifest
+)
+
 import click
 
 
@@ -312,3 +317,28 @@ def setup(
     click.echo(f"  Version: {pharmcat_resource['version']}")
     click.echo(f"  File: {pharmcat_resource['path']}")
     click.echo("PharmCAT positions resource downloaded successfully.")
+
+    click.echo()
+    click.echo("Writing installed resource manifest...")
+
+    try:
+        manifest = build_installed_manifest(
+            output_root=output_dir,
+            resource_version=resource_version,
+            bundled_resources=bundled_resources,
+            catalog_resources=catalog_resources,
+            clinvar_resources=clinvar_resources,
+            hpo_resource=hpo_resource,
+            pharmcat_resource=pharmcat_resource,
+            reference_resources=reference_resources,
+        )
+
+        manifest_path = write_installed_manifest(
+            output_root=output_dir,
+            manifest=manifest,
+        )
+    except ResourceOperationError as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(f"Installed resource manifest: {manifest_path}")
+    click.echo("SFtool resource setup completed successfully.")

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -5,11 +5,14 @@ Implementation of ``sftool resources setup``.
 from pathlib import Path
 from sftool.utils.catalog_utils import (
     CatalogGenerationError,
+    get_bundled_catalog_resource,
     prepare_catalog_resources,
 )
 
 from sftool.utils.clinvar_utils import (
     ClinVarProcessingError,
+    SUPPORTED_CLINVAR_EVIDENCE_LEVELS,
+    build_catalog_clinvar_databases,
     build_clinvar_databases,
     download_bundled_clinvar_snapshot,
 )
@@ -18,7 +21,9 @@ from sftool.utils.resource_utils import (
     load_bundled_resources,
     ResourceOperationError,
     ResourceSpecificationError,
-    download_versioned_resource
+    download_versioned_resource,
+    validate_hpo_gene_to_phenotype,
+    validate_vcf_resource
 )
 
 import click
@@ -57,16 +62,6 @@ Example:
     help="Directory where SFtool resources will be installed.",
 )
 @click.option(
-    "--clinvar-evidence",
-    type=click.IntRange(min=1, max=4),
-    default=1,
-    show_default=True,
-    help=(
-            "Minimum ClinVar evidence level used to generate the "
-            "processed ClinVar databases."
-    ),
-)
-@click.option(
     "--resource-version",
     type=click.Choice(
         ["bundled", "latest"],
@@ -92,7 +87,6 @@ Example:
 )
 def setup(
         output_dir: Path,
-        clinvar_evidence: int,
         resource_version: str,
         download_reference_genomes: bool,
 ) -> None:
@@ -130,7 +124,6 @@ def setup(
 
     click.echo("SFtool resource setup")
     click.echo(f"Output directory: {output_dir}")
-    click.echo(f"ClinVar evidence: {clinvar_evidence}")
     click.echo(f"Resource version: {resource_version}")
     click.echo(
         "Download reference genomes: "
@@ -223,6 +216,62 @@ def setup(
     )
 
     click.echo("Catalog resources prepared successfully.")
+
+    click.echo()
+    click.echo(
+        "Generating ClinVar databases by assembly, "
+        "catalog, and evidence level..."
+    )
+
+    try:
+        catalog_files = {
+            "PR": get_bundled_catalog_resource("PR"),
+            "RR": get_bundled_catalog_resource("RR"),
+        }
+
+        filtered_clinvar_databases = (
+            build_catalog_clinvar_databases(
+                assembly_databases=clinvar_databases,
+                submission_summary_path=Path(
+                    clinvar_resources["submission_summary"]
+                ),
+                catalog_files=catalog_files,
+                output_root=output_dir,
+                evidence_levels=(
+                    SUPPORTED_CLINVAR_EVIDENCE_LEVELS
+                ),
+            )
+        )
+
+        for assembly, assembly_resources in (
+                filtered_clinvar_databases.items()
+        ):
+            click.echo(f"  {assembly}")
+
+            for category, evidence_resources in (
+                    assembly_resources.items()
+            ):
+                click.echo(f"    {category}")
+
+                for evidence_level, database_path in (
+                        evidence_resources.items()
+                ):
+                    click.echo(
+                        f"      evidence {evidence_level}: "
+                        f"{database_path}"
+                    )
+
+        click.echo(
+            "ClinVar catalog/evidence databases "
+            "generated successfully."
+        )
+
+    except (
+            ClinVarProcessingError,
+            ResourceOperationError,
+    ) as error:
+        raise click.ClickException(str(error)) from error
+
 
     click.echo()
     click.echo("Downloading HPO resource...")

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -83,7 +83,12 @@ Example:
     "--download-reference-genomes",
     is_flag=True,
     default=False,
-    help="Download the GRCh37 and GRCh38 reference genomes.",
+    help=(
+            "Download the GRCh37 and GRCh38 reference genomes."
+            "Reserved for future reference genome download support. "
+            "Currently, users must provide their own reference genome "
+            "through the SFtool configuration."
+    ),
 )
 def setup(
         output_dir: Path,
@@ -98,11 +103,21 @@ def setup(
     resource-management tasks.
     """
 
+    if download_reference_genomes:
+        click.echo(
+            "Reference genome download is not implemented yet. "
+            "Users must currently provide their own reference genome "
+            "through the SFtool configuration. "
+            "This option is reserved for a future release.",
+            err=True,
+        )
+
+
     resource_version = resource_version.lower()
 
     if resource_version != "bundled":
         raise click.ClickException(
-            f"Unsupported resource version: {resource_version}"
+            f"Only bundled versions are implemented at the moment"
         )
 
     bundled_resources = load_bundled_resources()

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -33,7 +33,6 @@ from sftool.utils.manifest_utils import (
 
 import click
 
-
 SETUP_HELP = """
 Prepare the datasets and generated resources required by SFtool.
 
@@ -45,9 +44,10 @@ reference genomes.
 Example:
   sftool resources setup \\
     --output-dir /data/sftool_resources \\
-    --resource-version bundled \\
+    --resource-version-policy bundled \\
     --download-reference-genomes
 """
+
 
 
 @click.command(
@@ -66,7 +66,7 @@ Example:
     help="Directory where SFtool resources will be installed.",
 )
 @click.option(
-    "--resource-version",
+    "--resource-version-policy",
     type=click.Choice(
         ["bundled", "latest"],
         case_sensitive=False,
@@ -74,8 +74,8 @@ Example:
     default="bundled",
     show_default=True,
     help=(
-            "Resource version policy: use versions bundled with SFtool "
-            "or resolve the latest available versions."
+            "Resource selection policy: use versions bundled with "
+            "SFtool or resolve the latest available versions."
     ),
 )
 @click.option(
@@ -91,7 +91,7 @@ Example:
 )
 def setup(
         output_dir: Path,
-        resource_version: str,
+        resource_version_policy: str,
         download_reference_genomes: bool,
 ) -> None:
     """
@@ -111,13 +111,14 @@ def setup(
             err=True,
         )
 
+    resource_version_policy = resource_version_policy.lower()
 
-    resource_version = resource_version.lower()
-
-    if resource_version != "bundled":
+    if resource_version_policy != "bundled":
         raise click.ClickException(
-            f"Only bundled versions are implemented at the moment"
+            "Only the bundled resource version policy is implemented "
+            "at the moment"
         )
+
 
     bundled_resources = load_bundled_resources()
 
@@ -129,7 +130,7 @@ def setup(
 
     click.echo("SFtool resource setup")
     click.echo(f"Output directory: {output_dir}")
-    click.echo(f"Resource version: {resource_version}")
+    click.echo(f"Resource version policy: {resource_version_policy}")
     click.echo(
         "Download reference genomes: "
         f"{'yes' if download_reference_genomes else 'no'}"
@@ -324,7 +325,7 @@ def setup(
     try:
         manifest_path = write_installed_manifest(
             output_root=output_dir,
-            resource_version=resource_version,
+            resource_version_policy=resource_version_policy,
             catalog_resources=catalog_resources,
             clinvar_resources=clinvar_resources,
             clinvar_databases=clinvar_databases,

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -12,6 +12,16 @@ from sftool.utils.catalog_utils import (
     prepare_catalog_resources,
 )
 
+from sftool.utils.clinvar_utils import (
+    download_bundled_clinvar_snapshot,
+)
+
+from sftool.utils.resource_utils import (
+    load_bundled_resources,
+    ResourceOperationError,
+    ResourceSpecificationError,
+)
+
 import click
 
 
@@ -114,6 +124,36 @@ def setup(
     )
 
     click.echo()
+    click.echo("Downloading bundled ClinVar snapshot...")
+
+    try:
+        clinvar_resources = download_bundled_clinvar_snapshot(
+            output_root=output_dir,
+            clinvar_specification=bundled_resources["clinvar"],
+        )
+    except (
+            ResourceOperationError,
+            ResourceSpecificationError,
+    ) as error:
+        raise click.ClickException(str(error)) from error
+
+    click.echo(
+        "  Version: "
+        f"{clinvar_resources['version']}"
+    )
+    click.echo(
+        "  Variant summary: "
+        f"{clinvar_resources['variant_summary']}"
+    )
+    click.echo(
+        "  Submission summary: "
+        f"{clinvar_resources['submission_summary']}"
+    )
+    click.echo(
+        "ClinVar source snapshot downloaded successfully."
+    )
+
+    click.echo()
     click.echo("Preparing catalog resources...")
 
     try:
@@ -131,13 +171,13 @@ def setup(
     ):
         click.echo(f"  {assembly}")
 
-    for category, resources in catalogs.items():
-        click.echo(
-            f"    {category}: "
-            f"{resources['bed']}, "
-            f"{resources['chr_bed']}, "
-            f"{resources['json']}"
-        )
+        for category, resources in catalogs.items():
+            click.echo(
+                f"    {category}: "
+                f"{resources['bed']}, "
+                f"{resources['chr_bed']}, "
+                f"{resources['json']}"
+            )
 
     click.echo(
         "  RR_STR: "

--- a/sftool/commands/resources/setup.py
+++ b/sftool/commands/resources/setup.py
@@ -101,6 +101,7 @@ def setup(
     resource-management tasks.
     """
 
+    reference_resources = {}
     if download_reference_genomes:
         click.echo(
             "Reference genome download is not implemented yet. "
@@ -324,9 +325,10 @@ def setup(
         manifest = build_installed_manifest(
             output_root=output_dir,
             resource_version=resource_version,
-            bundled_resources=bundled_resources,
             catalog_resources=catalog_resources,
             clinvar_resources=clinvar_resources,
+            clinvar_databases=clinvar_databases,
+            filtered_clinvar_databases=filtered_clinvar_databases,
             hpo_resource=hpo_resource,
             pharmcat_resource=pharmcat_resource,
             reference_resources=reference_resources,

--- a/sftool/data/resources/bundled_resources.json
+++ b/sftool/data/resources/bundled_resources.json
@@ -9,12 +9,12 @@
   "hpo": {
     "version": "v2026-06-23",
     "url": "https://github.com/obophenotype/human-phenotype-ontology/releases/download/v2026-06-23/genes_to_phenotype.txt",
-    "filename": "genes_to_phenotype.txt"
+    "installed_filename": "genes_to_phenotype.txt"
   },
   "pharmcat": {
     "version": "3.4.0",
     "url": "https://github.com/PharmGKB/PharmCAT/releases/download/v3.4.0/pharmcat_positions_3.4.0.vcf",
-    "filename": "pharmcat_positions_3.4.0.vcf"
+    "installed_filename": "pharmcat_positions_3.4.0.vcf"
   },
   "reference_genomes": {
     "GRCh37": {

--- a/sftool/utils/catalog_utils.py
+++ b/sftool/utils/catalog_utils.py
@@ -52,6 +52,14 @@ CATALOG_SOURCE_FILES = {
     ),
 }
 
+RETRYABLE_STATUS_CODES = {
+    429,
+    500,
+    502,
+    503,
+    504,
+}
+
 class CatalogGenerationError(RuntimeError):
     """Raised when an SFtool catalog cannot be generated."""
 class GeneCoordinate(NamedTuple):
@@ -145,17 +153,116 @@ def read_catalog_csv(
     return catalog, genes
 
 
+def _get_ensembl_response(
+        url: str,
+        *,
+        timeout: float,
+        max_attempts: int = 5,
+) -> requests.Response:
+    """
+    Send a GET request to Ensembl, retrying transient network and HTTP errors.
+
+    Retries are performed for:
+
+    - Connection errors
+    - Timeouts
+    - HTTP 429
+    - HTTP 500
+    - HTTP 502
+    - HTTP 503
+    - HTTP 504
+
+    Non-transient HTTP errors, such as 400 or 404, are raised immediately.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be greater than or equal to 1")
+
+    last_error: requests.RequestException | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        response: requests.Response | None = None
+
+        try:
+            response = requests.get(
+                url,
+                timeout=timeout,
+            )
+
+            if response.status_code not in RETRYABLE_STATUS_CODES:
+                response.raise_for_status()
+                return response
+
+            response_body = response.text.strip()[:500]
+
+            last_error = requests.HTTPError(
+                (
+                        f"Ensembl returned HTTP {response.status_code}"
+                        + (
+                            f": {response_body}"
+                            if response_body
+                            else ""
+                        )
+                ),
+                response=response,
+            )
+
+        except (
+                requests.Timeout,
+                requests.ConnectionError,
+        ) as error:
+            last_error = error
+
+        except requests.RequestException:
+            # Do not retry non-transient errors such as HTTP 400 or 404.
+            raise
+
+        if attempt == max_attempts:
+            break
+
+        retry_after = None
+
+        if response is not None:
+            retry_after_header = response.headers.get("Retry-After")
+
+            if retry_after_header:
+                try:
+                    retry_after = float(retry_after_header)
+                except ValueError:
+                    retry_after = None
+
+        wait_seconds = (
+            retry_after
+            if retry_after is not None
+            else 2 ** (attempt - 1)
+        )
+
+        time.sleep(wait_seconds)
+
+    if last_error is None:
+        raise requests.RequestException(
+            f"Ensembl request failed for an unknown reason. URL: {url}"
+        )
+
+    raise last_error
+
+
 def get_gene_location_ensembl(
         gene_symbol: str,
         assembly: str,
         *,
         timeout: float = 30.0,
+        max_attempts: int = 5,
 ) -> dict[str, object]:
+    """
+    Retrieve genomic coordinates for a gene symbol from Ensembl.
+
+    Transient network and server errors are retried automatically.
+    """
     try:
         server = ENSEMBL_SERVERS[assembly]
     except KeyError as error:
         raise CatalogGenerationError(
-            f"Unsupported genome assembly: {assembly}"
+            f"Unsupported genome assembly: {assembly!r}"
         ) from error
 
     url = (
@@ -164,19 +271,107 @@ def get_gene_location_ensembl(
     )
 
     try:
-        response = requests.get(url, timeout=timeout)
-        response.raise_for_status()
-        data = response.json()
+        response = _get_ensembl_response(
+            url,
+            timeout=timeout,
+            max_attempts=max_attempts,
+        )
+
+    except requests.Timeout as error:
+        raise CatalogGenerationError(
+            f"Ensembl request timed out while retrieving coordinates "
+            f"for gene {gene_symbol!r} using {assembly}. "
+            f"Attempts: {max_attempts}. "
+            f"Timeout per attempt: {timeout} seconds. "
+            f"URL: {url}. "
+            f"Underlying error: {error}"
+        ) from error
+
+    except requests.ConnectionError as error:
+        raise CatalogGenerationError(
+            f"Could not connect to Ensembl while retrieving coordinates "
+            f"for gene {gene_symbol!r} using {assembly}. "
+            f"Attempts: {max_attempts}. "
+            f"Check the network connection and Ensembl server availability. "
+            f"URL: {url}. "
+            f"Underlying error: {error}"
+        ) from error
+
+    except requests.HTTPError as error:
+        error_response = error.response
+
+        status_code = (
+            error_response.status_code
+            if error_response is not None
+            else None
+        )
+
+        response_body = (
+            error_response.text.strip()[:500]
+            if error_response is not None
+            else ""
+        )
+
+        if status_code == 400:
+            reason = "Ensembl rejected the request"
+        elif status_code == 404:
+            reason = (
+                f"Gene {gene_symbol!r} was not found by Ensembl "
+                f"for {assembly}"
+            )
+        elif status_code == 429:
+            reason = (
+                "Ensembl rate limit exceeded after all retry attempts"
+            )
+        elif status_code in {500, 502, 503, 504}:
+            reason = (
+                "Ensembl returned a temporary server or gateway error "
+                "after all retry attempts"
+            )
+        else:
+            reason = "Ensembl returned an HTTP error"
+
+        message = (
+            f"{reason} while retrieving coordinates for gene "
+            f"{gene_symbol!r} using {assembly}. "
+            f"Attempts: {max_attempts}. "
+            f"URL: {url}"
+        )
+
+        if status_code is not None:
+            message += f". HTTP status: {status_code}"
+
+        if response_body:
+            message += f". Response: {response_body!r}"
+
+        raise CatalogGenerationError(message) from error
+
     except requests.RequestException as error:
         raise CatalogGenerationError(
-            f"Could not retrieve coordinates for gene "
-            f"{gene_symbol!r} using {assembly}"
+            f"Unexpected network error while retrieving coordinates "
+            f"for gene {gene_symbol!r} using {assembly}. "
+            f"Attempts: {max_attempts}. "
+            f"URL: {url}. "
+            f"Error type: {type(error).__name__}. "
+            f"Underlying error: {error}"
         ) from error
+
+    try:
+        data = response.json()
     except ValueError as error:
-        raise CatalogGenerationError(
+        response_body = response.text.strip()[:500]
+
+        message = (
             f"Invalid JSON returned by Ensembl for gene "
-            f"{gene_symbol!r} using {assembly}"
-        ) from error
+            f"{gene_symbol!r} using {assembly}. "
+            f"HTTP status: {response.status_code}. "
+            f"URL: {url}"
+        )
+
+        if response_body:
+            message += f". Response: {response_body!r}"
+
+        raise CatalogGenerationError(message) from error
 
     required_fields = {
         "seq_region_name",
@@ -184,10 +379,27 @@ def get_gene_location_ensembl(
         "end",
     }
 
-    if not isinstance(data, dict) or not required_fields.issubset(data):
+    if not isinstance(data, dict):
+        raise CatalogGenerationError(
+            f"Unexpected Ensembl response type for gene "
+            f"{gene_symbol!r} using {assembly}: expected a JSON object, "
+            f"received {type(data).__name__}. "
+            f"URL: {url}"
+        )
+
+    missing_fields = required_fields.difference(data)
+
+    if missing_fields:
+        available_fields = ", ".join(
+            sorted(map(str, data.keys()))
+        )
+
         raise CatalogGenerationError(
             f"Incomplete Ensembl response for gene "
-            f"{gene_symbol!r} using {assembly}"
+            f"{gene_symbol!r} using {assembly}. "
+            f"Missing fields: {', '.join(sorted(missing_fields))}. "
+            f"Available fields: {available_fields or 'none'}. "
+            f"URL: {url}"
         )
 
     return {

--- a/sftool/utils/catalog_utils.py
+++ b/sftool/utils/catalog_utils.py
@@ -6,6 +6,7 @@ Created on Tue Aug  8 19:07:52 2023
 @author: Javier Perez Florido, Edurne Urrutia
 """
 import csv
+import time
 from pathlib import Path
 import shutil
 from natsort import natsorted

--- a/sftool/utils/catalog_utils.py
+++ b/sftool/utils/catalog_utils.py
@@ -21,6 +21,8 @@ from sftool.utils.resource_utils import (
 
 GENERATED_CATALOGS = ("PR", "RR")
 
+CATALOG_VERSIONS = { "PR": "ACMG_SF_3.1", "RR": "ACMG_CS_2021", "RR_STR": "ACMG_CS_STR_2021", }
+
 CATALOG_DESCRIPTIONS = {
     "PR": "Secondary findings of personal risk",
     "RR": "Secondary findings of reproductive risk",
@@ -634,7 +636,9 @@ def prepare_catalog_resources(
 
     generated_catalogs: dict[str, object] = {
         "assemblies": {},
-        "RR_STR": {},
+        "RR_STR": {
+            "version": CATALOG_VERSIONS["RR_STR"],
+        },
     }
 
     for assembly in ("GRCh37", "GRCh38"):
@@ -642,7 +646,7 @@ def prepare_catalog_resources(
             output_root / "catalogs" / assembly
         )
 
-        assembly_catalogs: dict[str, dict[str, str]] = {}
+        assembly_catalogs: dict[str, dict[str, object]] = {}
 
         for category in GENERATED_CATALOGS:
             source_resource = get_bundled_catalog_resource(
@@ -658,8 +662,11 @@ def prepare_catalog_resources(
                 )
 
             assembly_catalogs[category] = {
-                name: str(path)
-                for name, path in outputs.items()
+                "version": CATALOG_VERSIONS[category],
+                **{
+                    name: str(path)
+                    for name, path in outputs.items()
+                },
             }
 
         generated_catalogs["assemblies"][assembly] = (
@@ -670,8 +677,6 @@ def prepare_catalog_resources(
         output_root
     )
 
-    generated_catalogs["RR_STR"] = {
-        "csv": str(rr_str_path),
-    }
+    generated_catalogs["RR_STR"]["csv"] = str(rr_str_path)
 
     return generated_catalogs

--- a/sftool/utils/clinvar_utils.py
+++ b/sftool/utils/clinvar_utils.py
@@ -10,10 +10,20 @@ import csv
 import urllib.request
 from datetime import datetime
 import shutil
-from sftool.utils.catalog_utils import read_csv
+from sftool.utils.catalog_utils import read_catalog_csv
 from collections import Counter
+from pathlib import Path
+from typing import Any
 import json
 
+from sftool.utils.resource_utils import (
+    ResourceOperationError,
+    ResourceSpecificationError,
+    download_file,
+    ensure_directory,
+    render_resource_filename,
+    resolve_resource_url,
+)
 
 def map_review_status(review_status):
     """
@@ -61,7 +71,7 @@ def run_clinvar(evidence_level, clinvar_db, clinvar_submission, category, catego
     try:
         # Select genes for current category
         # Read CSV and store it in a dictionary
-        genes_dct, genes_lst = read_csv(category_geneset_file, category)
+        genes_dct, genes_lst = read_catalog_csv(Path(category_geneset_file), category)
 
         # Read Clinvar database
         clinvar_dct = {}  #  dictionary to store information from CLINVAR
@@ -154,6 +164,99 @@ def run_clinvar(evidence_level, clinvar_db, clinvar_submission, category, catego
     except Exception as e:
         print(f"Error when filtering variants: {e}")
 
+
+def download_bundled_clinvar_snapshot(
+        *,
+        output_root: Path,
+        clinvar_specification: dict[str, Any],
+        overwrite: bool = False,
+) -> dict[str, str]:
+    """
+    Download the ClinVar files pinned by the bundled resource specification.
+
+    The source files are stored under::
+
+        <output_root>/clinvar/source/
+
+    Parameters
+    ----------
+    output_root
+        Root directory of the installed SFtool resources.
+    clinvar_specification
+        ``clinvar`` section loaded from ``bundled_resources.json``.
+    overwrite
+        Replace previously downloaded files when true.
+
+    Returns
+    -------
+    dict[str, str]
+        ClinVar version, source URLs, and downloaded paths.
+
+    Raises
+    ------
+    ResourceSpecificationError
+        If the bundled ClinVar definition is incomplete or invalid.
+    ResourceOperationError
+        If a source file cannot be downloaded.
+    """
+    output_root = Path(output_root)
+    source_directory = ensure_directory(
+        output_root / "clinvar" / "source"
+    )
+
+    try:
+        version = clinvar_specification["version"]
+        archive_base_url = clinvar_specification[
+            "archive_base_url"
+        ]
+        variant_summary_template = clinvar_specification[
+            "variant_summary_filename"
+        ]
+        submission_summary_template = clinvar_specification[
+            "submission_summary_filename"
+        ]
+    except KeyError as error:
+        raise ResourceSpecificationError(
+            "The bundled ClinVar specification is missing "
+            f"the required field: {error.args[0]}"
+        ) from error
+
+    variant_summary_filename = render_resource_filename(
+        variant_summary_template,
+        version=version,
+    )
+    submission_summary_filename = render_resource_filename(
+        submission_summary_template,
+        version=version,
+    )
+
+    variant_summary_url = resolve_resource_url(
+        archive_base_url,
+        variant_summary_filename,
+    )
+    submission_summary_url = resolve_resource_url(
+        archive_base_url,
+        submission_summary_filename,
+    )
+
+    variant_summary_path = download_file(
+        variant_summary_url,
+        source_directory / variant_summary_filename,
+        overwrite=overwrite,
+        )
+    submission_summary_path = download_file(
+        submission_summary_url,
+        source_directory / submission_summary_filename,
+        overwrite=overwrite,
+        )
+
+    return {
+        "version": version,
+        "variant_summary": str(variant_summary_path),
+        "submission_summary": str(submission_summary_path),
+        "variant_summary_url": variant_summary_url,
+        "submission_summary_url": submission_summary_url,
+    }
 
 def process_clinvar_data(assembly, release_date, clinvar_path):
     """

--- a/sftool/utils/clinvar_utils.py
+++ b/sftool/utils/clinvar_utils.py
@@ -4,6 +4,9 @@ Created on Sun Aug 13 15:12:18 2023
 
 @author: Javier Perez Florido, Edurne Urrutia
 """
+
+from __future__ import annotations
+
 import os
 import gzip
 import csv
@@ -15,6 +18,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 import json
+from collections.abc import Mapping
 
 from sftool.utils.resource_utils import (
     ResourceOperationError,
@@ -24,6 +28,206 @@ from sftool.utils.resource_utils import (
     render_resource_filename,
     resolve_resource_url,
 )
+
+SUPPORTED_CLINVAR_ASSEMBLIES = (
+    "GRCh37",
+    "GRCh38",
+)
+
+CLINVAR_DATABASE_COLUMNS = (
+    "Type",
+    "Name",
+    "GeneSymbol",
+    "ClinicalSignificance",
+    "ClinSigSimple",
+    "RS# (dbSNP)",
+    "VariationID",
+    "PhenotypeIDS",
+    "PhenotypeList",
+    "Assembly",
+    "Chromosome",
+    "Start",
+    "Stop",
+    "ReviewStatus",
+    "SubmitterCategories",
+    "PositionVCF",
+    "ReferenceAlleleVCF",
+    "AlternateAlleleVCF",
+)
+
+class ClinVarProcessingError(RuntimeError):
+    """Raised when a ClinVar source file cannot be processed."""
+
+def build_clinvar_assembly_database(
+        *,
+        variant_summary_path: Path,
+        output_root: Path,
+        assembly: str,
+        version: str,
+        overwrite: bool = False,
+) -> Path:
+    """
+    Generate the processed ClinVar database for one genome assembly.
+
+    Parameters
+    ----------
+    variant_summary_path
+        Path to the downloaded ClinVar ``variant_summary`` gzip file.
+    output_root
+        Root directory of the installed SFtool resources.
+    assembly
+        Genome assembly to retain: ``GRCh37`` or ``GRCh38``.
+    version
+        ClinVar version recorded in the bundled resource specification.
+    overwrite
+        Replace an existing generated database when true.
+
+    Returns
+    -------
+    Path
+        Generated assembly-specific ClinVar database.
+    """
+    variant_summary_path = Path(variant_summary_path)
+    output_root = Path(output_root)
+
+    if assembly not in SUPPORTED_CLINVAR_ASSEMBLIES:
+        raise ClinVarProcessingError(
+            f"Unsupported ClinVar assembly: {assembly}"
+        )
+
+    if not variant_summary_path.is_file():
+        raise ClinVarProcessingError(
+            "ClinVar variant summary does not exist or is not a file: "
+            f"{variant_summary_path}"
+        )
+
+    output_directory = ensure_directory(
+        output_root / "clinvar" / assembly
+    )
+
+    output_path = (
+            output_directory
+            / f"clinvar_database_{assembly}_{version}.txt"
+    )
+
+    if output_path.exists() and not overwrite:
+        return output_path
+
+    temporary_path = output_path.with_name(
+        f"{output_path.name}.tmp"
+    )
+
+    try:
+        with gzip.open(
+                variant_summary_path,
+                mode="rt",
+                encoding="utf-8",
+                newline="",
+        ) as source_handle:
+            reader = csv.reader(
+                source_handle,
+                delimiter="\t",
+            )
+
+            try:
+                header = next(reader)
+            except StopIteration as error:
+                raise ClinVarProcessingError(
+                    "ClinVar variant summary is empty: "
+                    f"{variant_summary_path}"
+                ) from error
+
+            missing_columns = [
+                column
+                for column in CLINVAR_DATABASE_COLUMNS
+                if column not in header
+            ]
+
+            if missing_columns:
+                raise ClinVarProcessingError(
+                    "ClinVar variant summary is missing required "
+                    f"columns: {', '.join(missing_columns)}"
+                )
+
+            column_positions = [
+                header.index(column)
+                for column in CLINVAR_DATABASE_COLUMNS
+            ]
+            assembly_position = header.index("Assembly")
+
+            with temporary_path.open(
+                    mode="w",
+                    encoding="utf-8",
+                    newline="",
+            ) as output_handle:
+                writer = csv.writer(
+                    output_handle,
+                    delimiter="\t",
+                    lineterminator="\n",
+                )
+
+                writer.writerow(CLINVAR_DATABASE_COLUMNS)
+
+                for line_number, row in enumerate(
+                        reader,
+                        start=2,
+                ):
+                    if len(row) != len(header):
+                        raise ClinVarProcessingError(
+                            "Malformed ClinVar row at line "
+                            f"{line_number}: expected {len(header)} "
+                            f"columns, found {len(row)}"
+                        )
+
+                    if row[assembly_position] != assembly:
+                        continue
+
+                    writer.writerow(
+                        row[position]
+                        for position in column_positions
+                    )
+
+        temporary_path.replace(output_path)
+
+    except ClinVarProcessingError:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    except (OSError, EOFError, gzip.BadGzipFile) as error:
+        temporary_path.unlink(missing_ok=True)
+
+        raise ClinVarProcessingError(
+            "Could not generate ClinVar database for "
+            f"{assembly} from {variant_summary_path}"
+        ) from error
+
+    return output_path
+
+def build_clinvar_databases(
+        *,
+        variant_summary_path: Path,
+        output_root: Path,
+        version: str,
+        assemblies: Sequence[str] = SUPPORTED_CLINVAR_ASSEMBLIES,
+        overwrite: bool = False,
+) -> dict[str, str]:
+    """
+    Generate the processed ClinVar databases for the requested assemblies.
+    """
+    databases: dict[str, str] = {}
+
+    for assembly in assemblies:
+        database_path = build_clinvar_assembly_database(
+            variant_summary_path=variant_summary_path,
+            output_root=output_root,
+            assembly=assembly,
+            version=version,
+            overwrite=overwrite,
+        )
+
+        databases[assembly] = str(database_path)
+
+    return databases
 
 def map_review_status(review_status):
     """

--- a/sftool/utils/clinvar_utils.py
+++ b/sftool/utils/clinvar_utils.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 import json
 from collections.abc import Mapping
+from sftool.utils.resource_utils import write_json
 
 from sftool.utils.resource_utils import (
     ResourceOperationError,
@@ -54,6 +55,28 @@ CLINVAR_DATABASE_COLUMNS = (
     "ReferenceAlleleVCF",
     "AlternateAlleleVCF",
 )
+
+SUPPORTED_CLINVAR_CATALOGS = (
+    "PR",
+    "RR",
+)
+
+SUPPORTED_CLINVAR_EVIDENCE_LEVELS = (
+    1,
+    2,
+    3,
+    4,
+)
+
+ALLOWED_CLINVAR_VARIANT_TYPES = {
+    "deletion",
+    "duplication",
+    "insertion",
+    "indel",
+    "single nucleotide variant",
+    "microsatellite",
+    "variation",
+}
 
 class ClinVarProcessingError(RuntimeError):
     """Raised when a ClinVar source file cannot be processed."""
@@ -228,6 +251,408 @@ def build_clinvar_databases(
         databases[assembly] = str(database_path)
 
     return databases
+
+def validate_clinvar_catalog(category: str) -> str:
+    normalized_category = category.upper()
+
+    if normalized_category not in SUPPORTED_CLINVAR_CATALOGS:
+        raise ClinVarProcessingError(
+            f"Unsupported ClinVar catalog: {category}. "
+            "Expected PR or RR."
+        )
+
+    return normalized_category
+
+
+def validate_clinvar_evidence_level(
+        evidence_level: int,
+) -> int:
+    try:
+        normalized_level = int(evidence_level)
+    except (TypeError, ValueError) as error:
+        raise ClinVarProcessingError(
+            f"Invalid ClinVar evidence level: {evidence_level}"
+        ) from error
+
+    if normalized_level not in SUPPORTED_CLINVAR_EVIDENCE_LEVELS:
+        raise ClinVarProcessingError(
+            "Unsupported ClinVar evidence level: "
+            f"{normalized_level}. Expected one of "
+            f"{SUPPORTED_CLINVAR_EVIDENCE_LEVELS}."
+        )
+
+    return normalized_level
+
+def load_clinvar_catalog_genes(
+        category: str,
+        category_geneset_file: Path,
+) -> set[str]:
+    normalized_category = validate_clinvar_catalog(category)
+
+    category_geneset_file = Path(category_geneset_file)
+
+    if not category_geneset_file.is_file():
+        raise ClinVarProcessingError(
+            "ClinVar catalog file does not exist: "
+            f"{category_geneset_file}"
+        )
+
+    try:
+        _, genes = read_catalog_csv(
+            category_geneset_file,
+            normalized_category,
+        )
+    except Exception as error:
+        raise ClinVarProcessingError(
+            "Could not read ClinVar catalog "
+            f"{normalized_category}: {category_geneset_file}"
+        ) from error
+
+    return {
+        str(gene).strip()
+        for gene in genes
+        if str(gene).strip()
+    }
+
+def load_clinvar_submission_summaries(
+        submission_summary_path: Path,
+) -> dict[str, str]:
+    submission_summary_path = Path(submission_summary_path)
+
+    if not submission_summary_path.is_file():
+        raise ClinVarProcessingError(
+            "ClinVar submission summary does not exist: "
+            f"{submission_summary_path}"
+        )
+
+    clinical_significance_data: dict[str, Counter] = {}
+
+    try:
+        with gzip.open(
+                submission_summary_path,
+                mode="rt",
+                encoding="utf-8",
+                newline="",
+        ) as source_handle:
+            header = None
+
+            for line in source_handle:
+                if line.startswith("#"):
+                    header = (
+                        line.lstrip("#")
+                        .rstrip("\n")
+                        .split("\t")
+                    )
+                    continue
+
+                if header is None:
+                    continue
+
+                row = dict(
+                    zip(
+                        header,
+                        line.rstrip("\n").split("\t"),
+                    )
+                )
+
+                variation_id = row.get("VariationID", "")
+                clinical_significance = (
+                    row.get("ClinicalSignificance", "").strip()
+                )
+                contributes = row.get(
+                    "ContributesToAggregateClassification",
+                    "",
+                )
+
+                if (
+                        not variation_id
+                        or not clinical_significance
+                        or contributes != "yes"
+                ):
+                    continue
+
+                counter = clinical_significance_data.setdefault(
+                    variation_id,
+                    Counter(),
+                )
+                counter[clinical_significance] += 1
+
+    except (
+            OSError,
+            EOFError,
+            gzip.BadGzipFile,
+    ) as error:
+        raise ClinVarProcessingError(
+            "Could not read ClinVar submission summary: "
+            f"{submission_summary_path}"
+        ) from error
+
+    return {
+        variation_id: "; ".join(
+            f"{label} ({count})"
+            for label, count in counter.items()
+        )
+        for variation_id, counter
+        in clinical_significance_data.items()
+    }
+
+def build_clinvar_variant_entry(
+        fields: list[str],
+        submission_summaries: Mapping[str, str],
+) -> tuple[str, dict[str, Any]] | None:
+    variant_type = fields[0]
+
+    if variant_type.lower() not in ALLOWED_CLINVAR_VARIANT_TYPES:
+        return None
+
+    position_vcf = fields[15]
+
+    try:
+        if int(position_vcf) == -1:
+            return None
+    except ValueError:
+        return None
+
+    variation_id = fields[6]
+
+    variant_key = (
+        f"{fields[10]}:"
+        f"{position_vcf}:"
+        f"{fields[16]}:"
+        f"{fields[17]}"
+    )
+
+    stars = map_review_status(fields[13])
+
+    entry = {
+        "VariantName": fields[1],
+        "Gene": fields[2],
+        "ClinicalSignificance": fields[3],
+        "ClinSigSimple": fields[4],
+        "rs": (
+            f"rs{fields[5]}"
+            if fields[5]
+            else ""
+        ),
+        "ReviewStatus": (
+            f"({stars}) {fields[13]}"
+        ),
+        "ClinvarID": variation_id,
+        "PhenotypeIDS": fields[7],
+        "ClinSigSummary": submission_summaries.get(
+            variation_id,
+            "",
+        ),
+    }
+
+    return variant_key, entry
+
+def build_catalog_clinvar_database(
+        *,
+        clinvar_database_path: Path,
+        submission_summaries: Mapping[str, str],
+        category: str,
+        category_geneset_file: Path,
+        assembly: str,
+        evidence_level: int,
+        output_root: Path,
+        overwrite: bool = False,
+) -> Path:
+    normalized_category = validate_clinvar_catalog(category)
+    normalized_evidence = validate_clinvar_evidence_level(
+        evidence_level
+    )
+
+    if assembly not in SUPPORTED_CLINVAR_ASSEMBLIES:
+        raise ClinVarProcessingError(
+            f"Unsupported ClinVar assembly: {assembly}"
+        )
+
+    clinvar_database_path = Path(clinvar_database_path)
+
+    if not clinvar_database_path.is_file():
+        raise ClinVarProcessingError(
+            "Processed ClinVar assembly database does not exist: "
+            f"{clinvar_database_path}"
+        )
+
+    catalog_genes = load_clinvar_catalog_genes(
+        normalized_category,
+        category_geneset_file,
+    )
+
+    output_directory = ensure_directory(
+        Path(output_root)
+        / "clinvar"
+        / assembly
+        / normalized_category
+    )
+
+    output_path = (
+            output_directory
+            / (
+                f"clinvar_{assembly}_"
+                f"{normalized_category}_"
+                f"evidence_{normalized_evidence}.json"
+            )
+    )
+
+    if output_path.exists() and not overwrite:
+        return output_path
+
+    variants: dict[str, dict[str, Any]] = {}
+
+    try:
+        with clinvar_database_path.open(
+                mode="r",
+                encoding="utf-8",
+                newline="",
+        ) as source_handle:
+            reader = csv.reader(
+                source_handle,
+                delimiter="\t",
+            )
+
+            try:
+                header = next(reader)
+            except StopIteration as error:
+                raise ClinVarProcessingError(
+                    "Processed ClinVar database is empty: "
+                    f"{clinvar_database_path}"
+                ) from error
+
+            if tuple(header) != CLINVAR_DATABASE_COLUMNS:
+                raise ClinVarProcessingError(
+                    "Unexpected processed ClinVar database header: "
+                    f"{clinvar_database_path}"
+                )
+
+            for line_number, fields in enumerate(
+                    reader,
+                    start=2,
+            ):
+                if len(fields) != len(CLINVAR_DATABASE_COLUMNS):
+                    raise ClinVarProcessingError(
+                        "Malformed processed ClinVar row at line "
+                        f"{line_number}: {clinvar_database_path}"
+                    )
+
+                row_genes = {
+                    gene.strip()
+                    for gene in fields[2].split(";")
+                    if gene.strip()
+                }
+
+                if catalog_genes.isdisjoint(row_genes):
+                    continue
+
+                stars = map_review_status(fields[13])
+
+                if stars < normalized_evidence:
+                    continue
+
+                result = build_clinvar_variant_entry(
+                    fields,
+                    submission_summaries,
+                )
+
+                if result is None:
+                    continue
+
+                variant_key, entry = result
+                variants[variant_key] = entry
+
+        write_json(
+            data=variants,
+            destination=output_path,
+        )
+
+    except ClinVarProcessingError:
+        raise
+    except OSError as error:
+        raise ClinVarProcessingError(
+            "Could not generate catalog ClinVar database: "
+            f"{output_path}"
+        ) from error
+
+    return output_path
+
+def build_catalog_clinvar_databases(
+        *,
+        assembly_databases: Mapping[str, str],
+        submission_summary_path: Path,
+        catalog_files: Mapping[str, Path],
+        output_root: Path,
+        evidence_levels: Sequence[int] = (
+                SUPPORTED_CLINVAR_EVIDENCE_LEVELS
+        ),
+        overwrite: bool = False,
+) -> dict[str, dict[str, dict[str, str]]]:
+    missing_assemblies = [
+        assembly
+        for assembly in SUPPORTED_CLINVAR_ASSEMBLIES
+        if assembly not in assembly_databases
+    ]
+
+    if missing_assemblies:
+        raise ClinVarProcessingError(
+            "Missing processed ClinVar databases for: "
+            f"{', '.join(missing_assemblies)}"
+        )
+
+    missing_catalogs = [
+        category
+        for category in SUPPORTED_CLINVAR_CATALOGS
+        if category not in catalog_files
+    ]
+
+    if missing_catalogs:
+        raise ClinVarProcessingError(
+            "Missing ClinVar catalog files for: "
+            f"{', '.join(missing_catalogs)}"
+        )
+
+    normalized_evidence_levels = [
+        validate_clinvar_evidence_level(level)
+        for level in evidence_levels
+    ]
+
+    submission_summaries = load_clinvar_submission_summaries(
+        submission_summary_path
+    )
+
+    generated: dict[
+        str,
+        dict[str, dict[str, str]],
+    ] = {}
+
+    for assembly in SUPPORTED_CLINVAR_ASSEMBLIES:
+        generated[assembly] = {}
+
+        for category in SUPPORTED_CLINVAR_CATALOGS:
+            generated[assembly][category] = {}
+
+            for evidence_level in normalized_evidence_levels:
+                output_path = build_catalog_clinvar_database(
+                    clinvar_database_path=Path(
+                        assembly_databases[assembly]
+                    ),
+                    submission_summaries=submission_summaries,
+                    category=category,
+                    category_geneset_file=Path(
+                        catalog_files[category]
+                    ),
+                    assembly=assembly,
+                    evidence_level=evidence_level,
+                    output_root=output_root,
+                    overwrite=overwrite,
+                )
+
+                generated[assembly][category][
+                    str(evidence_level)
+                ] = str(output_path)
+
+    return generated
 
 def map_review_status(review_status):
     """

--- a/sftool/utils/geneBe_utils.py
+++ b/sftool/utils/geneBe_utils.py
@@ -8,7 +8,7 @@ import os
 import gzip
 import io
 import vcfpy
-from sftool.utils.catalog_utils import read_csv
+from sftool.utils.catalog_utils import read_catalog_csv
 from pathlib import Path
 import re
 
@@ -133,7 +133,7 @@ def parse_genebe_output(genebe_output_vcf_file, variant_classification_sources, 
     try:
 
         # Get the list of genes for the current category
-        genes_dct, genes_lst = read_csv(category_geneset_file, category)
+        genes_dct, genes_lst = read_catalog_csv(category_geneset_file, category)
 
         # Read VCF file
         genebe_results = {}

--- a/sftool/utils/manifest_utils.py
+++ b/sftool/utils/manifest_utils.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+from sftool.utils.resource_utils import (
+    ResourceOperationError,
+    calculate_sha256,
+    read_json,
+    write_json,
+)
+
+
+INSTALLED_MANIFEST_SCHEMA_VERSION = 1
+INSTALLED_MANIFEST_FILENAME = "resources.json"
+
+
+def get_sftool_version() -> str:
+    try:
+        return version("sftool")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def utc_timestamp() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+
+def relative_resource_path(
+        path: Path | str,
+        output_root: Path,
+) -> str:
+    root = output_root.resolve()
+    resource_path = Path(path).resolve()
+
+    try:
+        relative_path = resource_path.relative_to(root)
+    except ValueError as error:
+        raise ResourceOperationError(
+            f"Resource path is outside the installation root: "
+            f"{resource_path}"
+        ) from error
+
+    return relative_path.as_posix()
+
+
+def describe_installed_file(
+        path: Path | str,
+        *,
+        output_root: Path,
+) -> dict[str, str]:
+    absolute_path = Path(path).resolve()
+    root = output_root.resolve()
+
+    try:
+        relative_path = absolute_path.relative_to(root)
+    except ValueError as exc:
+        raise ResourceOperationError(
+            f"Resource file is outside the installation root: "
+            f"{absolute_path}"
+        ) from exc
+
+    if not absolute_path.is_file():
+        raise ResourceOperationError(
+            f"Installed resource file does not exist: {absolute_path}"
+        )
+
+    return {
+        "path": relative_path.as_posix(),
+        "sha256": calculate_sha256(absolute_path),
+    }
+
+
+def build_catalog_manifest(
+        catalog_resources: dict[str, Any],
+        *,
+        output_root: Path,
+) -> dict[str, Any]:
+    manifest: dict[str, Any] = {}
+
+    for catalog_name, assemblies in catalog_resources.items():
+        manifest[catalog_name] = {}
+
+        for assembly, files in assemblies.items():
+            manifest[catalog_name][assembly] = {
+                "bed": describe_installed_file(
+                    files["bed"],
+                    output_root=output_root,
+                ),
+                "json": describe_installed_file(
+                    files["json"],
+                    output_root=output_root,
+                ),
+            }
+
+    return manifest
+
+def build_clinvar_manifest(
+        clinvar_resources: dict[str, Any],
+        *,
+        output_root: Path,
+) -> dict[str, Any]:
+    manifest: dict[str, Any] = {
+        "version": clinvar_resources["version"],
+        "files": {},
+    }
+
+    for catalog_name, assemblies in clinvar_resources["files"].items():
+        manifest["files"][catalog_name] = {}
+
+        for assembly, evidence_files in assemblies.items():
+            manifest["files"][catalog_name][assembly] = {}
+
+            for evidence_level, path in evidence_files.items():
+                manifest["files"][catalog_name][assembly][evidence_level] = (
+                    describe_installed_file(
+                        path,
+                        output_root=output_root,
+                    )
+                )
+
+    return manifest
+
+def build_reference_manifest(
+        reference_resources: dict[str, Any],
+        *,
+        output_root: Path,
+) -> dict[str, Any]:
+    manifest: dict[str, Any] = {}
+
+    for assembly, files in reference_resources.items():
+        manifest[assembly] = {
+            file_type: describe_installed_file(
+                path,
+                output_root=output_root,
+            )
+            for file_type, path in files.items()
+        }
+
+    return manifest
+
+def build_installed_manifest(
+        *,
+        output_root: Path,
+        resource_version: str,
+        catalog_resources: dict[str, Any],
+        clinvar_resources: dict[str, Any],
+        hpo_resource: dict[str, Any],
+        pharmcat_resource: dict[str, Any],
+        reference_resources: dict[str, Any] | None = None,
+        existing_manifest: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = utc_timestamp()
+
+    created_at = (
+        existing_manifest.get("created_at", now)
+        if existing_manifest
+        else now
+    )
+
+    datasets: dict[str, Any] = {
+        "catalogs": build_catalog_manifest(
+            catalog_resources,
+            output_root=output_root,
+        ),
+        "clinvar": build_clinvar_manifest(
+            clinvar_resources,
+            output_root=output_root,
+        ),
+        "hpo": {
+            "version": hpo_resource["version"],
+            "file": describe_installed_file(
+                hpo_resource["path"],
+                output_root=output_root,
+            ),
+        },
+        "pharmcat": {
+            "version": pharmcat_resource["version"],
+            "positions_vcf": describe_installed_file(
+                pharmcat_resource["positions_vcf"],
+                output_root=output_root,
+            ),
+        },
+    }
+
+    if reference_resources:
+        datasets["reference_genomes"] = build_reference_manifest(
+            reference_resources,
+            output_root=output_root,
+        )
+
+    return {
+        "schema_version": INSTALLED_MANIFEST_SCHEMA_VERSION,
+        "resource_version": resource_version,
+        "sftool_version": get_sftool_version(),
+        "created_at": created_at,
+        "updated_at": now,
+        "datasets": datasets,
+    }
+
+def validate_existing_manifest_compatibility(
+        existing_manifest: dict[str, Any],
+        *,
+        resource_version: str,
+) -> None:
+    existing_schema_version = existing_manifest.get(
+        "schema_version"
+    )
+
+    if existing_schema_version != INSTALLED_MANIFEST_SCHEMA_VERSION:
+        raise ResourceOperationError(
+            "The existing resource manifest uses an unsupported "
+            f"schema version: {existing_schema_version!r}"
+        )
+
+    existing_resource_version = existing_manifest.get(
+        "resource_version"
+    )
+
+    if existing_resource_version != resource_version:
+        raise ResourceOperationError(
+            "The resource directory was installed using resource "
+            f"version {existing_resource_version!r}, but the requested "
+            f"version is {resource_version!r}."
+        )
+
+def write_installed_manifest(
+        *,
+        output_root: Path,
+        resource_version: str,
+        bundled_resources: dict[str, Any],
+        catalog_resources: dict[str, Any],
+        clinvar_resources: dict[str, Any],
+        hpo_resource: dict[str, Any],
+        pharmcat_resource: dict[str, Any],
+        reference_resources: dict[str, Any] | None = None,
+) -> Path:
+    manifest_path = output_root / "resources.json"
+
+    existing_manifest: dict[str, Any] | None = None
+
+    if manifest_path.exists():
+        existing_manifest = read_json(manifest_path)
+
+        validate_existing_manifest_compatibility(
+            existing_manifest,
+            resource_version=resource_version,
+        )
+
+    manifest = build_installed_manifest(
+        output_root=output_root,
+        resource_version=resource_version,
+        bundled_resources=bundled_resources,
+        catalog_resources=catalog_resources,
+        clinvar_resources=clinvar_resources,
+        hpo_resource=hpo_resource,
+        pharmcat_resource=pharmcat_resource,
+        reference_resources=reference_resources,
+        existing_manifest=existing_manifest,
+    )
+
+    return write_json(
+        manifest,
+        manifest_path,
+    )

--- a/sftool/utils/manifest_utils.py
+++ b/sftool/utils/manifest_utils.py
@@ -13,7 +13,7 @@ from sftool.utils.resource_utils import (
 )
 
 
-INSTALLED_MANIFEST_SCHEMA_VERSION = 1
+INSTALLED_MANIFEST_SCHEMA_VERSION = 2
 INSTALLED_MANIFEST_FILENAME = "resources.json"
 
 
@@ -55,6 +55,7 @@ def describe_installed_file(
         path: Path | str,
         *,
         output_root: Path,
+        source_url: str | None = None,
 ) -> dict[str, str]:
     root = output_root.resolve()
     resource_path = Path(path)
@@ -77,10 +78,15 @@ def describe_installed_file(
             f"Installed resource file does not exist: {absolute_path}"
         )
 
-    return {
+    descriptor = {
         "path": relative_path.as_posix(),
         "sha256": calculate_sha256(absolute_path),
     }
+
+    if source_url is not None:
+        descriptor["source_url"] = source_url
+
+    return descriptor
 
 def build_catalog_manifest(
         catalog_resources: dict[str, Any],
@@ -96,24 +102,26 @@ def build_catalog_manifest(
     for assembly, catalogs in assemblies.items():
         manifest["assemblies"][assembly] = {}
 
-        for catalog_name, files in catalogs.items():
+        for catalog_name, resources in catalogs.items():
             manifest["assemblies"][assembly][catalog_name] = {
+                "version": resources["version"],
                 "bed": describe_installed_file(
-                    files["bed"],
+                    resources["bed"],
                     output_root=output_root,
                 ),
                 "chr_bed": describe_installed_file(
-                    files["chr_bed"],
+                    resources["chr_bed"],
                     output_root=output_root,
                 ),
                 "json": describe_installed_file(
-                    files["json"],
+                    resources["json"],
                     output_root=output_root,
                 ),
             }
 
     if "RR_STR" in catalog_resources:
         manifest["RR_STR"] = {
+            "version": catalog_resources["RR_STR"]["version"],
             "csv": describe_installed_file(
                 catalog_resources["RR_STR"]["csv"],
                 output_root=output_root,
@@ -152,6 +160,22 @@ def build_clinvar_manifest(
 ) -> dict[str, Any]:
     return {
         "version": clinvar_resources["version"],
+        "source_files": {
+            "variant_summary": describe_installed_file(
+                clinvar_resources["variant_summary"],
+                output_root=output_root,
+                source_url=clinvar_resources[
+                    "variant_summary_url"
+                ],
+            ),
+            "submission_summary": describe_installed_file(
+                clinvar_resources["submission_summary"],
+                output_root=output_root,
+                source_url=clinvar_resources[
+                    "submission_summary_url"
+                ],
+            ),
+        },
         "databases": describe_file_tree(
             clinvar_databases,
             output_root=output_root,
@@ -183,7 +207,7 @@ def build_reference_manifest(
 def build_installed_manifest(
         *,
         output_root: Path,
-        resource_version: str,
+        resource_version_policy: str,
         catalog_resources: dict[str, Any],
         clinvar_resources: dict[str, Any],
         clinvar_databases: dict[str, Any],
@@ -218,6 +242,7 @@ def build_installed_manifest(
             "file": describe_installed_file(
                 hpo_resource["path"],
                 output_root=output_root,
+                source_url=hpo_resource["source_url"],
             ),
         },
         "pharmcat": {
@@ -225,6 +250,7 @@ def build_installed_manifest(
             "positions_vcf": describe_installed_file(
                 pharmcat_resource["path"],
                 output_root=output_root,
+                source_url=pharmcat_resource["source_url"],
             ),
         },
     }
@@ -237,7 +263,7 @@ def build_installed_manifest(
 
     return {
         "schema_version": INSTALLED_MANIFEST_SCHEMA_VERSION,
-        "resource_version": resource_version,
+        "resource_version_policy": resource_version_policy,
         "sftool_version": get_sftool_version(),
         "created_at": created_at,
         "updated_at": now,
@@ -247,7 +273,7 @@ def build_installed_manifest(
 def validate_existing_manifest_compatibility(
         existing_manifest: dict[str, Any],
         *,
-        resource_version: str,
+        resource_version_policy: str,
 ) -> None:
     existing_schema_version = existing_manifest.get(
         "schema_version"
@@ -259,21 +285,25 @@ def validate_existing_manifest_compatibility(
             f"schema version: {existing_schema_version!r}"
         )
 
-    existing_resource_version = existing_manifest.get(
-        "resource_version"
+    existing_resource_version_policy = existing_manifest.get(
+        "resource_version_policy"
     )
 
-    if existing_resource_version != resource_version:
+    if (
+            existing_resource_version_policy
+            != resource_version_policy
+    ):
         raise ResourceOperationError(
             "The resource directory was installed using resource "
-            f"version {existing_resource_version!r}, but the requested "
-            f"version is {resource_version!r}."
+            f"version policy "
+            f"{existing_resource_version_policy!r}, but the requested "
+            f"policy is {resource_version_policy!r}."
         )
 
 def write_installed_manifest(
         *,
         output_root: Path,
-        resource_version: str,
+        resource_version_policy: str,
         catalog_resources: dict[str, Any],
         clinvar_resources: dict[str, Any],
         clinvar_databases: dict[str, Any],
@@ -282,7 +312,7 @@ def write_installed_manifest(
         pharmcat_resource: dict[str, Any],
         reference_resources: dict[str, Any] | None = None,
 ) -> Path:
-    manifest_path = output_root / "resources.json"
+    manifest_path = output_root / INSTALLED_MANIFEST_FILENAME
 
     existing_manifest: dict[str, Any] | None = None
 
@@ -291,12 +321,12 @@ def write_installed_manifest(
 
         validate_existing_manifest_compatibility(
             existing_manifest,
-            resource_version=resource_version,
+            resource_version_policy=resource_version_policy,
         )
 
     manifest = build_installed_manifest(
         output_root=output_root,
-        resource_version=resource_version,
+        resource_version_policy=resource_version_policy,
         catalog_resources=catalog_resources,
         clinvar_resources=clinvar_resources,
         clinvar_databases=clinvar_databases,

--- a/sftool/utils/manifest_utils.py
+++ b/sftool/utils/manifest_utils.py
@@ -51,14 +51,18 @@ def relative_resource_path(
 
     return relative_path.as_posix()
 
-
 def describe_installed_file(
         path: Path | str,
         *,
         output_root: Path,
 ) -> dict[str, str]:
-    absolute_path = Path(path).resolve()
     root = output_root.resolve()
+    resource_path = Path(path)
+
+    if resource_path.is_absolute():
+        absolute_path = resource_path.resolve()
+    else:
+        absolute_path = (root / resource_path).resolve()
 
     try:
         relative_path = absolute_path.relative_to(root)
@@ -78,21 +82,28 @@ def describe_installed_file(
         "sha256": calculate_sha256(absolute_path),
     }
 
-
 def build_catalog_manifest(
         catalog_resources: dict[str, Any],
         *,
         output_root: Path,
 ) -> dict[str, Any]:
-    manifest: dict[str, Any] = {}
+    manifest: dict[str, Any] = {
+        "assemblies": {},
+    }
 
-    for catalog_name, assemblies in catalog_resources.items():
-        manifest[catalog_name] = {}
+    assemblies = catalog_resources.get("assemblies", {})
 
-        for assembly, files in assemblies.items():
-            manifest[catalog_name][assembly] = {
+    for assembly, catalogs in assemblies.items():
+        manifest["assemblies"][assembly] = {}
+
+        for catalog_name, files in catalogs.items():
+            manifest["assemblies"][assembly][catalog_name] = {
                 "bed": describe_installed_file(
                     files["bed"],
+                    output_root=output_root,
+                ),
+                "chr_bed": describe_installed_file(
+                    files["chr_bed"],
                     output_root=output_root,
                 ),
                 "json": describe_installed_file(
@@ -101,33 +112,55 @@ def build_catalog_manifest(
                 ),
             }
 
+    if "RR_STR" in catalog_resources:
+        manifest["RR_STR"] = {
+            "csv": describe_installed_file(
+                catalog_resources["RR_STR"]["csv"],
+                output_root=output_root,
+            ),
+        }
+
+    return manifest
+
+def describe_file_tree(
+        resources: dict[str, Any],
+        *,
+        output_root: Path,
+) -> dict[str, Any]:
+    manifest: dict[str, Any] = {}
+
+    for key, value in resources.items():
+        if isinstance(value, dict):
+            manifest[key] = describe_file_tree(
+                value,
+                output_root=output_root,
+            )
+        else:
+            manifest[key] = describe_installed_file(
+                value,
+                output_root=output_root,
+            )
+
     return manifest
 
 def build_clinvar_manifest(
         clinvar_resources: dict[str, Any],
+        clinvar_databases: dict[str, Any],
+        filtered_clinvar_databases: dict[str, Any],
         *,
         output_root: Path,
 ) -> dict[str, Any]:
-    manifest: dict[str, Any] = {
+    return {
         "version": clinvar_resources["version"],
-        "files": {},
+        "databases": describe_file_tree(
+            clinvar_databases,
+            output_root=output_root,
+        ),
+        "filtered_databases": describe_file_tree(
+            filtered_clinvar_databases,
+            output_root=output_root,
+        ),
     }
-
-    for catalog_name, assemblies in clinvar_resources["files"].items():
-        manifest["files"][catalog_name] = {}
-
-        for assembly, evidence_files in assemblies.items():
-            manifest["files"][catalog_name][assembly] = {}
-
-            for evidence_level, path in evidence_files.items():
-                manifest["files"][catalog_name][assembly][evidence_level] = (
-                    describe_installed_file(
-                        path,
-                        output_root=output_root,
-                    )
-                )
-
-    return manifest
 
 def build_reference_manifest(
         reference_resources: dict[str, Any],
@@ -153,11 +186,14 @@ def build_installed_manifest(
         resource_version: str,
         catalog_resources: dict[str, Any],
         clinvar_resources: dict[str, Any],
+        clinvar_databases: dict[str, Any],
+        filtered_clinvar_databases: dict[str, Any],
         hpo_resource: dict[str, Any],
         pharmcat_resource: dict[str, Any],
         reference_resources: dict[str, Any] | None = None,
         existing_manifest: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+
     now = utc_timestamp()
 
     created_at = (
@@ -173,6 +209,8 @@ def build_installed_manifest(
         ),
         "clinvar": build_clinvar_manifest(
             clinvar_resources,
+            clinvar_databases,
+            filtered_clinvar_databases,
             output_root=output_root,
         ),
         "hpo": {
@@ -185,7 +223,7 @@ def build_installed_manifest(
         "pharmcat": {
             "version": pharmcat_resource["version"],
             "positions_vcf": describe_installed_file(
-                pharmcat_resource["positions_vcf"],
+                pharmcat_resource["path"],
                 output_root=output_root,
             ),
         },
@@ -236,9 +274,10 @@ def write_installed_manifest(
         *,
         output_root: Path,
         resource_version: str,
-        bundled_resources: dict[str, Any],
         catalog_resources: dict[str, Any],
         clinvar_resources: dict[str, Any],
+        clinvar_databases: dict[str, Any],
+        filtered_clinvar_databases: dict[str, Any],
         hpo_resource: dict[str, Any],
         pharmcat_resource: dict[str, Any],
         reference_resources: dict[str, Any] | None = None,
@@ -258,9 +297,10 @@ def write_installed_manifest(
     manifest = build_installed_manifest(
         output_root=output_root,
         resource_version=resource_version,
-        bundled_resources=bundled_resources,
         catalog_resources=catalog_resources,
         clinvar_resources=clinvar_resources,
+        clinvar_databases=clinvar_databases,
+        filtered_clinvar_databases=filtered_clinvar_databases,
         hpo_resource=hpo_resource,
         pharmcat_resource=pharmcat_resource,
         reference_resources=reference_resources,

--- a/sftool/utils/resource_utils.py
+++ b/sftool/utils/resource_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Mapping, Callable
 import shutil
 
 
@@ -19,6 +19,15 @@ BUNDLED_RESOURCE_PACKAGE = "sftool.data.resources"
 BUNDLED_RESOURCE_FILENAME = "bundled_resources.json"
 SUPPORTED_BUNDLED_SCHEMA_VERSIONS = {1}
 
+
+EXPECTED_HPO_COLUMNS = [
+    "ncbi_gene_id",
+    "gene_symbol",
+    "hpo_id",
+    "hpo_name",
+    "frequency",
+    "disease_id",
+]
 
 class ResourceSpecificationError(ValueError):
     """
@@ -189,8 +198,13 @@ def _validate_download_specification(
         required_fields={
             "version",
             "url",
-            "filename",
+            "installed_filename",
         },
+    )
+
+    render_resource_filename(
+        specification["installed_filename"],
+        version=specification["version"],
     )
 
 
@@ -667,3 +681,77 @@ def read_json(path: Path) -> dict[str, Any]:
         )
 
     return data
+
+def download_versioned_resource(
+        *,
+        output_root: Path,
+        resource_name: str,
+        specification: Mapping[str, Any],
+        validator: Callable[[Path], None] | None = None,
+) -> dict[str, str]:
+    version = specification["version"]
+
+    filename = render_resource_filename(
+        specification["installed_filename"],
+        version=version,
+    )
+
+    destination = (
+            Path(output_root)
+            / resource_name
+            / filename
+    )
+
+    path = download_file(
+        url=specification["url"],
+        destination=destination,
+    )
+
+    if validator is not None:
+        validator(path)
+
+    return {
+        "version": version,
+        "source_url": specification["url"],
+        "path": path.relative_to(output_root).as_posix(),
+        "sha256": calculate_sha256(path),
+    }
+
+def validate_hpo_gene_to_phenotype(path: Path) -> None:
+    path = Path(path)
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            header = handle.readline().rstrip("\r\n")
+    except OSError as error:
+        raise ResourceOperationError(
+            f"Could not read HPO resource: {path}"
+        ) from error
+
+    if not header:
+        raise ResourceOperationError(
+            f"HPO resource is empty: {path}"
+        )
+
+    actual_columns = header.split("\t")
+
+    if actual_columns != EXPECTED_HPO_COLUMNS:
+        raise ResourceOperationError(
+            "HPO resource has an unexpected header. "
+            f"Expected {EXPECTED_HPO_COLUMNS}, "
+            f"found {actual_columns}: {path}"
+        )
+
+def validate_vcf_resource(path: Path) -> None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            first_line = handle.readline().strip()
+    except OSError as error:
+        raise ResourceOperationError(
+            f"Could not read downloaded VCF resource: {path}"
+        ) from error
+
+    if not first_line.startswith("##fileformat=VCF"):
+        raise ResourceOperationError(
+            f"Downloaded file is not a valid VCF resource: {path}"
+        )

--- a/tests/utils/test_clinvar_resources.py
+++ b/tests/utils/test_clinvar_resources.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import csv
 import gzip
+import json
 from click.testing import CliRunner
 
 from sftool.utils import clinvar_utils
@@ -10,7 +11,8 @@ from sftool.utils.clinvar_utils import (
     download_bundled_clinvar_snapshot,
     build_clinvar_databases,
     CLINVAR_DATABASE_COLUMNS,
-    build_clinvar_assembly_database
+    build_clinvar_assembly_database,
+    build_catalog_clinvar_databases
 )
 from sftool.utils.resource_utils import (
     ResourceSpecificationError,
@@ -317,3 +319,86 @@ def test_build_clinvar_databases_generates_both_assemblies(
         "GRCh37",
         "GRCh38",
     }
+
+
+def test_build_catalog_clinvar_databases_creates_all_combinations(
+        tmp_path,
+):
+    # ------------------------------------------------------------------
+    # Create the input files required by build_catalog_clinvar_databases
+    # ------------------------------------------------------------------
+
+    grch37_database = tmp_path / "clinvar_database_GRCh37.txt"
+    grch38_database = tmp_path / "clinvar_database_GRCh38.txt"
+
+    submission_summary = tmp_path / "submission_summary.txt.gz"
+
+    pr_catalog = tmp_path / "PR.csv"
+    rr_catalog = tmp_path / "RR.csv"
+
+    output_root = tmp_path / "resources"
+
+    # The assembly-specific ClinVar databases are tab-separated files.
+    # For this test, only the header is required because we are testing
+    # generation of all output combinations, not variant filtering.
+    clinvar_header = "\t".join(CLINVAR_DATABASE_COLUMNS) + "\n"
+
+    grch37_database.write_text(
+        clinvar_header,
+        encoding="utf-8",
+    )
+
+    grch38_database.write_text(
+        clinvar_header,
+        encoding="utf-8",
+    )
+
+    # The submission summary must be gzip-compressed and contain a valid
+    # header. No data rows are required for this test.
+    with gzip.open(
+            submission_summary,
+            mode="wt",
+            encoding="utf-8",
+    ) as handle:
+        handle.write(
+            "#VariationID\t"
+            "ClinicalSignificance\t"
+            "ContributesToAggregateClassification\n"
+        )
+
+    # read_catalog_csv requires a column named exactly "Gene".
+    pr_catalog.write_text(
+        "Gene\nGENE_PR\n",
+        encoding="latin1",
+    )
+
+    rr_catalog.write_text(
+        "Gene\nGENE_RR\n",
+        encoding="latin1",
+    )
+
+    # ------------------------------------------------------------------
+    # Run
+    # ------------------------------------------------------------------
+
+    build_catalog_clinvar_databases(
+        assembly_databases={
+            "GRCh37": grch37_database,
+            "GRCh38": grch38_database,
+        },
+        submission_summary_path=submission_summary,
+        catalog_files={
+            "PR": pr_catalog,
+            "RR": rr_catalog,
+        },
+        output_root=output_root,
+    )
+
+    # ------------------------------------------------------------------
+    # Assert
+    # ------------------------------------------------------------------
+
+    generated_paths = list(output_root.rglob("*.json"))
+
+    assert len(generated_paths) == 16
+    assert all(path.is_file() for path in generated_paths)

--- a/tests/utils/test_clinvar_resources.py
+++ b/tests/utils/test_clinvar_resources.py
@@ -1,11 +1,16 @@
 from pathlib import Path
 
 import pytest
+import csv
+import gzip
 from click.testing import CliRunner
 
 from sftool.utils import clinvar_utils
 from sftool.utils.clinvar_utils import (
     download_bundled_clinvar_snapshot,
+    build_clinvar_databases,
+    CLINVAR_DATABASE_COLUMNS,
+    build_clinvar_assembly_database
 )
 from sftool.utils.resource_utils import (
     ResourceSpecificationError,
@@ -174,3 +179,141 @@ def test_download_bundled_clinvar_snapshot_rejects_missing_field(
             clinvar_specification=specification,
         )
 
+
+def test_build_clinvar_assembly_database_filters_assembly(
+        tmp_path,
+):
+    source_path = tmp_path / "variant_summary.txt.gz"
+
+    header = list(CLINVAR_DATABASE_COLUMNS)
+
+    grch37_row = [
+        "single nucleotide variant",
+        "variant 37",
+        "GENE1",
+        "Pathogenic",
+        "1",
+        "123",
+        "1001",
+        "MONDO:1",
+        "Disease 1",
+        "GRCh37",
+        "1",
+        "100",
+        "100",
+        "criteria provided, single submitter",
+        "1",
+        "100",
+        "A",
+        "G",
+    ]
+
+    grch38_row = [
+        "single nucleotide variant",
+        "variant 38",
+        "GENE2",
+        "Pathogenic",
+        "1",
+        "456",
+        "1002",
+        "MONDO:2",
+        "Disease 2",
+        "GRCh38",
+        "2",
+        "200",
+        "200",
+        "reviewed by expert panel",
+        "1",
+        "200",
+        "C",
+        "T",
+    ]
+
+    with gzip.open(
+            source_path,
+            "wt",
+            encoding="utf-8",
+            newline="",
+    ) as handle:
+        writer = csv.writer(
+            handle,
+            delimiter="\t",
+            lineterminator="\n",
+        )
+        writer.writerow(header)
+        writer.writerow(grch37_row)
+        writer.writerow(grch38_row)
+
+    output_path = build_clinvar_assembly_database(
+        variant_summary_path=source_path,
+        output_root=tmp_path / "resources",
+        assembly="GRCh37",
+        version="2026-06",
+    )
+
+    rows = list(
+        csv.reader(
+            output_path.open(encoding="utf-8"),
+            delimiter="\t",
+        )
+    )
+
+    assert rows == [
+        header,
+        grch37_row,
+    ]
+
+def test_build_clinvar_databases_generates_both_assemblies(
+        tmp_path,
+        monkeypatch,
+):
+    calls = []
+
+    def fake_build_clinvar_assembly_database(
+            *,
+            variant_summary_path,
+            output_root,
+            assembly,
+            version,
+            overwrite,
+    ):
+        calls.append(assembly)
+
+        output_path = (
+                output_root
+                / "clinvar"
+                / assembly
+                / f"clinvar_database_{assembly}_{version}.txt"
+        )
+        output_path.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+        output_path.write_text(
+            "header\n",
+            encoding="utf-8",
+        )
+
+        return output_path
+
+    monkeypatch.setattr(
+        clinvar_utils,
+        "build_clinvar_assembly_database",
+        fake_build_clinvar_assembly_database,
+    )
+
+    resources = build_clinvar_databases(
+        variant_summary_path=tmp_path / "variant_summary.txt.gz",
+        output_root=tmp_path / "resources",
+        version="2026-06",
+    )
+
+    assert calls == [
+        "GRCh37",
+        "GRCh38",
+    ]
+
+    assert set(resources) == {
+        "GRCh37",
+        "GRCh38",
+    }

--- a/tests/utils/test_clinvar_resources.py
+++ b/tests/utils/test_clinvar_resources.py
@@ -1,0 +1,176 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from sftool.utils import clinvar_utils
+from sftool.utils.clinvar_utils import (
+    download_bundled_clinvar_snapshot,
+)
+from sftool.utils.resource_utils import (
+    ResourceSpecificationError,
+)
+
+
+def test_download_bundled_clinvar_snapshot(
+        tmp_path,
+        monkeypatch,
+):
+    downloaded: list[tuple[str, Path, bool]] = []
+
+    def fake_download_file(
+            url,
+            destination,
+            *,
+            overwrite=False,
+            **kwargs,
+    ):
+        destination = Path(destination)
+        destination.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+        destination.write_bytes(b"clinvar-test-data")
+
+        downloaded.append(
+            (url, destination, overwrite)
+        )
+
+        return destination
+
+    monkeypatch.setattr(
+        clinvar_utils,
+        "download_file",
+        fake_download_file,
+    )
+
+    specification = {
+        "version": "2026-06",
+        "archive_base_url": (
+            "https://ftp.ncbi.nlm.nih.gov/"
+            "pub/clinvar/tab_delimited/archive/"
+        ),
+        "variant_summary_filename": (
+            "variant_summary_{version}.txt.gz"
+        ),
+        "submission_summary_filename": (
+            "submission_summary_{version}.txt.gz"
+        ),
+    }
+
+    result = download_bundled_clinvar_snapshot(
+        output_root=tmp_path,
+        clinvar_specification=specification,
+    )
+
+    source_directory = (
+            tmp_path / "clinvar" / "source"
+    )
+
+    expected_variant_summary = (
+            source_directory
+            / "variant_summary_2026-06.txt.gz"
+    )
+    expected_submission_summary = (
+            source_directory
+            / "submission_summary_2026-06.txt.gz"
+    )
+
+    assert expected_variant_summary.exists()
+    assert expected_submission_summary.exists()
+
+    assert result["version"] == "2026-06"
+    assert result["variant_summary"] == str(
+        expected_variant_summary
+    )
+    assert result["submission_summary"] == str(
+        expected_submission_summary
+    )
+
+    assert len(downloaded) == 2
+
+    assert downloaded[0][0].endswith(
+        "/variant_summary_2026-06.txt.gz"
+    )
+    assert downloaded[1][0].endswith(
+        "/submission_summary_2026-06.txt.gz"
+    )
+
+
+def test_download_bundled_clinvar_snapshot_reuses_files(
+        tmp_path,
+        monkeypatch,
+):
+    calls = 0
+
+    def fake_download_file(
+            url,
+            destination,
+            *,
+            overwrite=False,
+            **kwargs,
+    ):
+        nonlocal calls
+        calls += 1
+
+        destination = Path(destination)
+        destination.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+
+        if not destination.exists():
+            destination.write_bytes(b"clinvar-test-data")
+
+        return destination
+
+    monkeypatch.setattr(
+        clinvar_utils,
+        "download_file",
+        fake_download_file,
+    )
+
+    specification = {
+        "version": "2026-06",
+        "archive_base_url": "https://example.org/archive/",
+        "variant_summary_filename": (
+            "variant_summary_{version}.txt.gz"
+        ),
+        "submission_summary_filename": (
+            "submission_summary_{version}.txt.gz"
+        ),
+    }
+
+    first = download_bundled_clinvar_snapshot(
+        output_root=tmp_path,
+        clinvar_specification=specification,
+    )
+    second = download_bundled_clinvar_snapshot(
+        output_root=tmp_path,
+        clinvar_specification=specification,
+    )
+
+    assert first == second
+    assert calls == 4
+
+
+def test_download_bundled_clinvar_snapshot_rejects_missing_field(
+        tmp_path,
+):
+    specification = {
+        "version": "2026-06",
+        "archive_base_url": "https://example.org/archive/",
+        "variant_summary_filename": (
+            "variant_summary_{version}.txt.gz"
+        ),
+    }
+
+    with pytest.raises(
+            ResourceSpecificationError,
+            match="submission_summary_filename",
+    ):
+        download_bundled_clinvar_snapshot(
+            output_root=tmp_path,
+            clinvar_specification=specification,
+        )
+

--- a/tests/utils/test_manifest_utils.py
+++ b/tests/utils/test_manifest_utils.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+import pytest
+
+from sftool.utils.manifest_utils import (
+    build_catalog_manifest,
+    build_installed_manifest,
+    describe_installed_file,
+)
+
+from sftool.utils.resource_utils import ResourceOperationError
+from sftool.utils.manifest_utils import describe_installed_file
+
+def test_describe_installed_file(tmp_path: Path) -> None:
+    output_root = tmp_path / "resources"
+    output_root.mkdir()
+
+    resource = output_root / "hpo" / "hp.obo"
+    resource.parent.mkdir()
+    resource.write_text("test")
+
+    descriptor = describe_installed_file(
+        resource,
+        output_root=output_root,
+    )
+
+    assert descriptor["path"] == "hpo/hp.obo"
+    assert "sha256" in descriptor
+
+def test_describe_installed_file_outside_root(tmp_path: Path) -> None:
+    output_root = tmp_path / "resources"
+    output_root.mkdir()
+
+    resource = tmp_path / "outside.txt"
+    resource.write_text("test", encoding="utf-8")
+
+    with pytest.raises(
+            ResourceOperationError,
+            match="outside the installation root",
+    ):
+        describe_installed_file(
+            resource,
+            output_root=output_root,
+        )
+
+def test_build_catalog_manifest(tmp_path: Path) -> None:
+    output_root = tmp_path / "resources"
+    output_root.mkdir()
+
+    bed = output_root / "catalogs" / "PR" / "GRCh38" / "pr.bed"
+    json = output_root / "catalogs" / "PR" / "GRCh38" / "pr.json"
+
+    bed.parent.mkdir(parents=True)
+    bed.write_text("bed")
+    json.write_text("{}")
+
+    manifest = build_catalog_manifest(
+        {
+            "PR": {
+                "GRCh38": {
+                    "bed": bed,
+                    "json": json,
+                }
+            }
+        },
+        output_root=output_root,
+    )
+
+    assert manifest["PR"]["GRCh38"]["bed"]["path"] == "catalogs/PR/GRCh38/pr.bed"
+    assert manifest["PR"]["GRCh38"]["json"]["path"] == "catalogs/PR/GRCh38/pr.json"
+
+
+def test_build_installed_manifest(tmp_path: Path) -> None:
+    output_root = tmp_path / "resources"
+    output_root.mkdir()
+
+    hpo = output_root / "hpo" / "hp.obo"
+    pharmcat = output_root / "pharmcat" / "positions.vcf.gz"
+
+    hpo.parent.mkdir()
+    pharmcat.parent.mkdir()
+
+    hpo.write_text("ontology")
+    pharmcat.write_text("vcf")
+
+    manifest = build_installed_manifest(
+        output_root=output_root,
+        resource_version="stable",
+        catalog_resources={},
+        clinvar_resources={"version": "2026-07", "files": {}},
+        hpo_resource={
+            "version": "2026-06",
+            "path": hpo,
+        },
+        pharmcat_resource={
+            "version": "3.0.0",
+            "positions_vcf": pharmcat,
+        },
+    )
+
+    assert manifest["resource_version"] == "stable"
+    assert manifest["datasets"]["hpo"]["file"]["path"] == "hpo/hp.obo"
+    assert (
+            manifest["datasets"]["pharmcat"]["positions_vcf"]["path"]
+            == "pharmcat/positions.vcf.gz"
+    )

--- a/tests/utils/test_resource_utils.py
+++ b/tests/utils/test_resource_utils.py
@@ -18,7 +18,20 @@ from sftool.utils.resource_utils import (
     write_json,
     load_bundled_resources,
     validate_bundled_resources,
+    download_versioned_resource,
+    validate_hpo_gene_to_phenotype,
+    validate_vcf_resource,
 )
+
+HPO_HEADER = (
+    "ncbi_gene_id\t"
+    "gene_symbol\t"
+    "hpo_id\t"
+    "hpo_name\t"
+    "frequency\t"
+    "disease_id"
+)
+
 
 
 def test_load_bundled_resources() -> None:
@@ -71,12 +84,12 @@ def valid_resource_specification() -> dict:
         "hpo": {
             "version": "test-version",
             "url": "https://example.org/genes_to_phenotype.txt",
-            "filename": "genes_to_phenotype.txt",
+            "installed_filename": "genes_to_phenotype.txt",
         },
         "pharmcat": {
             "version": "test-version",
             "url": "https://example.org/pharmcat_positions.vcf",
-            "filename": "pharmcat_positions.vcf",
+            "installed_filename": "pharmcat_positions.vcf",
         },
         "reference_genomes": {
             "GRCh37": {
@@ -236,3 +249,106 @@ def test_download_file_cleans_up_after_failure(tmp_path: Path) -> None:
 
     assert not destination.exists()
     assert not partial_path.exists()
+
+def test_download_versioned_resource_creates_expected_path(
+        tmp_path,
+        monkeypatch,
+):
+    specification = {
+        "version": "v2026-06-23",
+        "url": "https://example.org/genes_to_phenotype.txt",
+        "installed_filename": "genes_to_phenotype_{version}.txt",
+    }
+
+    def fake_download_file(url, destination, **kwargs):
+        assert url == specification["url"]
+
+        destination.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+        destination.write_text(
+            f"{HPO_HEADER}\n"
+            "1\tA1BG\tHP:0000001\tAll\t-\tOMIM:123456\n",
+            encoding="utf-8",
+        )
+
+        return destination
+
+    monkeypatch.setattr(
+        "sftool.utils.resource_utils.download_file",
+        fake_download_file,
+    )
+
+    result = download_versioned_resource(
+        output_root=tmp_path,
+        resource_name="hpo",
+        specification=specification,
+        validator=validate_hpo_gene_to_phenotype,
+    )
+
+    expected_path = (
+            tmp_path
+            / "hpo"
+            / "genes_to_phenotype_v2026-06-23.txt"
+    )
+
+    assert expected_path.is_file()
+    assert result["version"] == "v2026-06-23"
+    assert result["source_url"] == specification["url"]
+    assert result["path"] == (
+        "hpo/genes_to_phenotype_v2026-06-23.txt"
+    )
+    assert result["sha256"]
+
+
+def test_validate_hpo_gene_to_phenotype_accepts_valid_file(
+        tmp_path,
+):
+    hpo_path = tmp_path / "genes_to_phenotype.txt"
+
+    hpo_path.write_text(
+        "ncbi_gene_id\t"
+        "gene_symbol\t"
+        "hpo_id\t"
+        "hpo_name\t"
+        "frequency\t"
+        "disease_id\n"
+        "1\tA1BG\tHP:0000001\tAll\t-\tOMIM:123456\n",
+        encoding="utf-8",
+    )
+
+    validate_hpo_gene_to_phenotype(hpo_path)
+
+
+def test_validate_hpo_gene_to_phenotype_rejects_invalid_header(
+        tmp_path,
+):
+    hpo_path = tmp_path / "genes_to_phenotype.txt"
+
+    hpo_path.write_text(
+        "ncbi_gene_id\tgene_symbol\thpo_id\n"
+        "1\tA1BG\tHP:0000001\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+            ResourceOperationError,
+            match="unexpected header",
+    ):
+        validate_hpo_gene_to_phenotype(hpo_path)
+
+
+def test_validate_vcf_resource_accepts_valid_vcf(
+        tmp_path,
+):
+    vcf_path = tmp_path / "pharmcat_positions.vcf"
+
+    vcf_path.write_text(
+        "##fileformat=VCFv4.2\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "1\t100\t.\tA\tG\t.\tPASS\t.\n",
+        encoding="utf-8",
+    )
+
+    validate_vcf_resource(vcf_path)


### PR DESCRIPTION
## Summary
Implements Phase 3 of the SFtool resource-management workflow by generating catalog- and evidence-specific ClinVar resources for PR and RR analyses. The workflow prepares cumulative ClinVar JSON files for GRCh37 and GRCh38 across all supported evidence levels, retains the original ClinVar source files and assembly-level databases, and records all generated resources, versions, paths, and checksums in the installation manifest.

## Related Issue
Refs #58 

## Type of change
- [X] Feature (feat)
- [ ] Bug fix (fix)
- [X] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [X] Tests
- [ ] Maintenance / Chore

## Checklist
- [X] Code compiles and runs
- [X] Tests added or updated
- [ ] Documentation updated
- [ ] Linked the related issue (e.g., "Refs #58 ")
