### PR TITLE
 Resource Management Workflow: Phase 4 — Bootstrap and runtime resource resolution

### DIFF
--- a/examples/config.schema.json
+++ b/examples/config.schema.json
@@ -3,14 +3,14 @@
   "title": "SFtool config schema",
   "type": "object",
 
-  "required": ["paths", "references", "catalogs", "clinvar", "genebe_credentials", "smaca_thresholds"],
+  "required": ["paths", "resources","references", "genebe_credentials", "smaca_thresholds"],
 
   "properties": {
     "version": { "type": "string" },
 
     "paths": {
       "type": "object",
-      "required": ["categories", "clinvar_db", "bcftools", "htslib", "genebe", "java", "python", "pharmCAT"],
+      "required": ["categories", "bcftools", "htslib", "genebe", "java", "python", "pharmCAT"],
       "properties": {
         "categories": { "type": "string" },
         "bcftools": { "type": "string" },
@@ -21,39 +21,47 @@
         "pharmCAT": { "type": "string" }
       }
     },
-
-    "references": {
+    "resources": {
       "type": "object",
-      "required": ["genomes", "gene_to_phenotype_file"],
+      "additionalProperties": false,
+      "required": [
+        "manifest"
+      ],
       "properties": {
-        "gene_to_phenotype_file": { "type": "string" },
-        "genomes": {
-          "type": "object",
-          "required": ["GRCh37", "GRCh38"],
-          "properties": {
-            "GRCh37": { "type": "string" },
-            "GRCh38": { "type": "string" }
-          }
+        "manifest": {
+          "type": "string",
+          "minLength": 1
         }
       }
     },
 
-    "catalogs": {
+    "references": {
       "type": "object",
-      "required": ["personal_risk_geneset", "reproductive_risk_geneset", "reproductive_risk_geneset_STR"],
+      "additionalProperties": false,
       "properties": {
-        "personal_risk_geneset": { "type": "string" },
-        "reproductive_risk_geneset": { "type": "string" },
-        "reproductive_risk_geneset_STR": { "type": "string" }
-      }
-    },
-
-    "clinvar": {
-      "type": "object",
-      "required": ["version", "db_path"],
-      "properties": {
-        "version": { "type": "string" },
-        "db_path": { "type": "string" }
+        "genomes": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "GRCh37": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "minLength": 1
+            },
+            "GRCh38": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "minLength": 1
+            }
+          }
+        }
       }
     },
 

--- a/examples/config_example.json
+++ b/examples/config_example.json
@@ -10,27 +10,17 @@
     "python": "/home/jpflorido/miniconda3/envs/pharmcat_py312/bin/python",
     "pharmCAT": "/home/jpflorido/software/pharmCAT/3.2.0/pharmcat-pipeline-3.2.0/pharmcat.jar"
   },
+  "resources":
+  {
+    "manifest": "/data/software/sftool/resources.json"
+  },
 
   "references": {
     "genomes": {
-      "GRCh37": "/data/reference_genome/hs37d5/hs37d5.fa",
+      "GRCh37": null,
       "GRCh38": "/data/reference_genome/hg38/hg38_no_alt.fa"
-    },
-    "gene_to_phenotype_file": "/home/jpflorido/GBPA/projects/SFtool/sftool/data/categories/genes_to_phenotype_20260623.txt",
-    "pharmCAT_positions_vcf": "/mnt/lustre/scratch/CBRA/projects/ACCI/secondary_findings/resources/pharmcat_positions_3.2.0.vcf"
+    }
   },
-
-  "catalogs": {
-    "personal_risk_geneset": "/home/jpflorido/GBPA/projects/SFtool/sftool/data/categories/PR/PR_risk_genes_ACMG_SF_v3.1.csv",
-    "reproductive_risk_geneset": "/home/jpflorido/GBPA/projects/SFtool/sftool/data/categories/RR/RR_risk_genes_ACMG_CS_v2021.csv",
-    "reproductive_risk_geneset_STR": "/home/jpflorido/GBPA/projects/SFtool/sftool/data/categories/RR/RR_risk_genes_STR_ACMG_CS_v2021.csv"
-  },
-
-  "clinvar": {
-    "version": "20260615",
-    "db_path": "/home/jpflorido/software/clinvar/"
-  },
-
   "genebe_credentials": {
     "api_key": "ak-fuwmE37xOkhfh6jquUt0LzOKT",
     "username": "javier.perez.florido.sspa@juntadeandalucia.es"

--- a/sftool/core/bootstrap.py
+++ b/sftool/core/bootstrap.py
@@ -21,6 +21,11 @@ from sftool.utils.vcf_utils import (
     validate_chr_prefix,
     check_vcf_positions_present
 )
+from sftool.core.resources import (
+    RuntimeResources,
+    load_resource_manifest,
+    resolve_execution_resources,
+)
 
 
 SUPPORTED_EXECUTION_MODES = {
@@ -84,20 +89,58 @@ def bootstrap_execution(
     # Legacy-equivalent validations (dict-level)
     # -----------------------------------------------------------------
     validate_samples_info(samples_info)
-    validate_config(config_data, samples_info)
+    validate_config(config_data)
 
     # -----------------------------------------------------------------
     # Instantiate Config (run-level)
     # -----------------------------------------------------------------
     config = Config(config_data)
+
+    # -----------------------------------------------------------------
+    # Load manifest file and resources
+    # -----------------------------------------------------------------
+    raw_manifest, installed_resources = (
+        load_resource_manifest(
+            config.resources.manifest
+        )
+    )
+
+    execution_meta = samples_info["execution"]
+
+    required_categories = get_required_resource_categories(
+        samples_info
+    )
+
+    selected_resources = resolve_execution_resources(
+        assembly=execution_meta["reference_genome"],
+        clinvar_evidence=execution_meta["clinvar_evidence"],
+        categories=required_categories,
+        configured_genomes=config.references.genomes,
+        installed=installed_resources,
+    )
+
+    runtime_resources = RuntimeResources(
+        manifest_path=config.resources.manifest,
+        manifest=raw_manifest,
+        installed=installed_resources,
+        execution=selected_resources,
+    )
+
+    config.resources.raw_manifest = raw_manifest
+    config.resources.installed = installed_resources
+
+    # -----------------------------------------------------------------
+    # Check runtime dependencies
+    # -----------------------------------------------------------------
     check_runtime_dependencies(config.paths)
 
     # -----------------------------------------------------------------
     # Build ExecutionContext
     # -----------------------------------------------------------------
     ctx = ExecutionContext(
-        execution_meta=samples_info["execution"],
+        execution_meta=execution_meta,
         config=config,
+        resources=runtime_resources,
         output_dir=output_dir,
         tmp_dir=tmp_dir,
     )
@@ -439,140 +482,201 @@ def validate_variant_confirmation_requests(samples: list[Dict[str, Any]], modes:
 
         request["variant"] = variant.strip()
 
-def validate_config(config: Dict[str, Any], samples_info: dict | None = None):
-    required = [
-        "paths", "references", "catalogs",
-        "clinvar", "genebe_credentials", "smaca_thresholds"
-    ]
-
-    for key in required:
-        if key not in config:
-            raise ValidationError(f"Missing '{key}' block in config.json")
-
-    # Shorthand variables
-    references = config["references"]
-    catalogs = config["catalogs"]
-    clinvar = config["clinvar"]
-
-    # ----------------------------------------------------
-    # Validate reference genomes exist
-    # ----------------------------------------------------
-    if "genomes" not in references:
-        raise ValidationError("Missing 'references.genomes' block in config.json")
-
-    for name, path in references["genomes"].items():
-        if not isinstance(path, str) or path == "":
-            raise ValidationError(f"Invalid reference genome path for '{name}'")
-
-        if not os.path.exists(path):
-            raise ValidationError(
-                f"Reference genome '{name}' does not exist at: {path}"
-            )
-
-    # ----------------------------------------------------
-    # Validate gene_to_phenotype file existence
-    # ----------------------------------------------------
-    if "gene_to_phenotype_file" not in references:
-        raise ValidationError("Missing 'references.gene_to_phenotype_file' in config.json")
-
-    g2p = references["gene_to_phenotype_file"]
-
-    if not os.path.exists(g2p):
+def validate_resource_config(resources: Dict[str, Any]) -> None:
+    if not isinstance(resources, dict):
         raise ValidationError(
-            f"gene_to_phenotype_file does not exist: {g2p}"
+            "'resources' must be an object"
         )
 
-    # ----------------------------------------------------
-    # Validate pharmCAT_positions_vcf file existence when PGx category exists
-    # ----------------------------------------------------
+    manifest = resources.get("manifest")
 
-    requested_categories = set()
-
-    if samples_info is not None:
-        requested_categories = {
-            category
-            for sample in samples_info["samples"]
-            for category in sample.get("categories", [])
-        }
-
-    if "PGx" in requested_categories:
-        if "pharmCAT_positions_vcf" not in references:
-            raise ValidationError("Missing 'references.pharmCAT_positions_vcf' in config.json")
-
-        pharmCAT_positions = references["pharmCAT_positions_vcf"]
-
-        if not os.path.exists(pharmCAT_positions):
-            raise ValidationError(
-                f"pharmCAT_positions_vcf does not exist: {pharmCAT_positions}"
-            )
-
-    # ----------------------------------------------------
-    # Validate catalogs (PR, RR, STR, PGx) file existence
-    # ----------------------------------------------------
-    for label, path in catalogs.items():
-        if not os.path.exists(path):
-            raise ValidationError(
-                f"Catalog file for '{label}' does not exist: {path}"
-            )
-
-    # ----------------------------------------------------
-    # Validate clinvar.version follows YYYYMMDD
-    # ----------------------------------------------------
-    if "version" not in clinvar:
-        raise ValidationError("Missing 'clinvar.version' field in config.json")
-
-    version = clinvar["version"]
-
-    # must be string of 8 digits
-    if not (isinstance(version, str) and (version == "latest" or (len(version) == 8 and version.isdigit()))):
-            raise ValidationError(
-                f"Invalid clinvar.version '{version}'. Expected YYYYMMDD (8 digits) or 'latest' string for the downloading of the latest Clinvar version."
-            )
-
-    if version != "latest":
-        # split into components
-        year = int(version[0:4])
-        month = int(version[4:6])
-        day = int(version[6:8])
-
-        # year range
-        if not (2015 <= year <= 2030):
-            raise ValidationError(
-                f"Invalid clinvar.version year '{year}'. Must be 2000–2030."
-            )
-
-        # month range
-        if not (1 <= month <= 12):
-            raise ValidationError(
-                f"Invalid clinvar.version month '{month:02d}'. Must be 01–12."
-            )
-
-        # days per month (default February 28, updated later if leap year)
-        days_in_month = {
-            1: 31, 2: 28, 3: 31, 4: 30, 5: 31, 6: 30,
-            7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31
-        }
-
-        # leap year adjustment
-        if (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0):
-            days_in_month[2] = 29
-
-        # day range
-        if not (1 <= day <= days_in_month[month]):
-            raise ValidationError(
-                f"Invalid clinvar.version day '{day:02d}' for month {month:02d}."
-            )
-
-    # ----------------------------------------------------
-    # Validate clinvar.db_path existence
-    # ----------------------------------------------------
-    if "db_path" not in clinvar:
-        raise ValidationError("Missing 'clinvar.db_path' in config.json")
-
-    if not os.path.exists(clinvar["db_path"]):
+    if not isinstance(manifest, str) or not manifest.strip():
         raise ValidationError(
-            f"ClinVar database path does not exist: {clinvar['db_path']}"
+            "resources.manifest must be a non-empty string"
         )
+
+    manifest_path = Path(manifest).expanduser()
+
+    if not manifest_path.exists():
+        raise ValidationError(
+            f"Resource manifest does not exist: {manifest_path}"
+        )
+
+    if not manifest_path.is_file():
+        raise ValidationError(
+            f"Resource manifest is not a file: {manifest_path}"
+        )
+
+def validate_reference_config(
+        references: Dict[str, Any],
+) -> None:
+    if not isinstance(references, dict):
+        raise ValidationError(
+            "'references' must be an object"
+        )
+
+    unknown_fields = set(references) - {"genomes"}
+
+    if unknown_fields:
+        raise ValidationError(
+            "Unsupported field(s) in references: "
+            + ", ".join(sorted(unknown_fields))
+        )
+
+    genomes = references.get("genomes", {})
+
+    if not isinstance(genomes, dict):
+        raise ValidationError(
+            "references.genomes must be an object"
+        )
+
+    unsupported_assemblies = (
+            set(genomes) - SUPPORTED_REFERENCE_GENOMES
+    )
+
+    if unsupported_assemblies:
+        raise ValidationError(
+            "Unsupported reference genome override(s): "
+            + ", ".join(sorted(unsupported_assemblies))
+        )
+
+    for assembly, value in genomes.items():
+        if value is None:
+            continue
+
+        if not isinstance(value, str) or not value.strip():
+            raise ValidationError(
+                f"references.genomes.{assembly} must be "
+                "a non-empty string or null"
+            )
+
+        fasta_path = Path(value).expanduser()
+
+        if not fasta_path.exists():
+            raise ValidationError(
+                f"Reference genome override for {assembly} "
+                f"does not exist: {fasta_path}"
+            )
+
+        if not fasta_path.is_file():
+            raise ValidationError(
+                f"Reference genome override for {assembly} "
+                f"is not a file: {fasta_path}"
+            )
+
+        fai_path = Path(f"{fasta_path}.fai")
+
+        if not fai_path.is_file():
+            raise ValidationError(
+                f"Reference genome index for {assembly} "
+                f"does not exist: {fai_path}"
+            )
+
+def validate_paths_config(paths: Dict[str, Any]) -> None:
+    if not isinstance(paths, dict):
+        raise ValidationError("'paths' must be an object")
+
+    required_paths = {
+        "bcftools",
+        "java",
+        "genebe",
+        "bgzip",
+        "python",
+        "pharmCAT",
+    }
+
+    missing = required_paths - paths.keys()
+
+    if missing:
+        raise ValidationError(
+            "Missing required path(s): "
+            + ", ".join(sorted(missing))
+        )
+
+    for name in required_paths:
+        value = paths[name]
+
+        if not isinstance(value, str) or not value.strip():
+            raise ValidationError(
+                f"paths.{name} must be a non-empty string"
+            )
+
+def validate_genebe_config(
+        credentials: Dict[str, Any],
+) -> None:
+    if not isinstance(credentials, dict):
+        raise ValidationError(
+            "'genebe_credentials' must be an object"
+        )
+
+    for field in ("api_key", "username"):
+        value = credentials.get(field)
+
+        if not isinstance(value, str):
+            raise ValidationError(
+                f"genebe_credentials.{field} must be a string"
+            )
+
+def validate_smaca_config(
+        thresholds: Dict[str, Any],
+) -> None:
+    if not isinstance(thresholds, dict):
+        raise ValidationError(
+            "'smaca_thresholds' must be an object"
+        )
+
+    required = {
+        "cv_fail",
+        "cv_warn",
+        "low_cov_absolute",
+        "low_cov_relative",
+    }
+
+    missing = required - thresholds.keys()
+
+    if missing:
+        raise ValidationError(
+            "Missing SMAca threshold(s): "
+            + ", ".join(sorted(missing))
+        )
+
+    for field in required:
+        value = thresholds[field]
+
+        if (
+                not isinstance(value, (int, float))
+                or isinstance(value, bool)
+        ):
+            raise ValidationError(
+                f"smaca_thresholds.{field} must be numeric"
+            )
+
+def validate_config(config: Dict[str, Any]) -> None:
+    if not isinstance(config, dict):
+        raise ValidationError(
+            "config must be a JSON object"
+        )
+
+    required_blocks = {
+        "paths",
+        "resources",
+        "genebe_credentials",
+        "smaca_thresholds",
+    }
+
+    missing = required_blocks - config.keys()
+
+    if missing:
+        raise ValidationError(
+            "Missing required block(s) in config.json: "
+            + ", ".join(sorted(missing))
+        )
+
+    validate_paths_config(config["paths"])
+    validate_resource_config(config["resources"])
+    validate_reference_config(config.get("references", {}))
+    validate_genebe_config(config["genebe_credentials"])
+    validate_smaca_config(config["smaca_thresholds"])
 
 
 

--- a/sftool/core/bootstrap.py
+++ b/sftool/core/bootstrap.py
@@ -25,8 +25,11 @@ from sftool.core.resources import (
     RuntimeResources,
     validate_resource_bundle,
     resolve_execution_resources,
-    get_required_resource_categories
+    get_required_resource_categories,
+    SUPPORTED_CLINVAR_EVIDENCE_LEVELS
 )
+
+
 
 
 SUPPORTED_EXECUTION_MODES = {
@@ -273,7 +276,7 @@ def validate_execution_block(exec_data: Dict[str, Any], num_samples):
 
     # -------- Validate ClinVar evidence --------
     ce = exec_data["clinvar_evidence"]
-    if not isinstance(ce, int) or not (1 <= ce <= 5) or isinstance(ce, bool):
+    if not isinstance(ce, int) or ce not in SUPPORTED_CLINVAR_EVIDENCE_LEVELS or isinstance(ce, bool):
         raise ValidationError("execution.clinvar_evidence must be an integer between 1 and 5")
 
     # =====================================================

--- a/sftool/core/bootstrap.py
+++ b/sftool/core/bootstrap.py
@@ -23,7 +23,7 @@ from sftool.utils.vcf_utils import (
 )
 from sftool.core.resources import (
     RuntimeResources,
-    load_resource_manifest,
+    validate_resource_bundle,
     resolve_execution_resources,
     get_required_resource_categories
 )
@@ -98,10 +98,10 @@ def bootstrap_execution(
     config = Config(config_data)
 
     # -----------------------------------------------------------------
-    # Load manifest file and resources
+    # Validate (and load) manifest file and resources
     # -----------------------------------------------------------------
     raw_manifest, installed_resources = (
-        load_resource_manifest(
+        validate_resource_bundle(
             config.resources.manifest
         )
     )

--- a/sftool/core/bootstrap.py
+++ b/sftool/core/bootstrap.py
@@ -25,6 +25,7 @@ from sftool.core.resources import (
     RuntimeResources,
     load_resource_manifest,
     resolve_execution_resources,
+    get_required_resource_categories
 )
 
 
@@ -756,6 +757,6 @@ def _validate_pgx_inputs(ctx: ExecutionContext):
 
             check_vcf_positions_present(
                 input_vcf=pgx_vcf,
-                required_vcf=ctx.config.references.pharmCAT_positions_vcf,
+                required_vcf=ctx.resources.execution["pharmcat"]["positions_vcf"]["path"],
                 output_file=ctx.tmp_dir / "PGx" / f"{sample.sample_id}.missing_pharmcat_positions.tsv"
             )

--- a/sftool/core/config.py
+++ b/sftool/core/config.py
@@ -126,6 +126,18 @@ class ReferenceDataConfig:
                 "references.genomes must be an object"
             )
 
+        unexpected = set(genomes) - {
+            "GRCh37",
+            "GRCh38",
+        }
+
+        if unexpected:
+            raise ValueError(
+                "references.genomes contains unsupported "
+                "assembly key(s): "
+                + ", ".join(sorted(unexpected))
+            )
+
         self.genomes: dict[str, Path | None] = {}
 
         for assembly in ("GRCh37", "GRCh38"):
@@ -146,7 +158,6 @@ class ReferenceDataConfig:
                 .expanduser()
                 .resolve()
             )
-
 class PathsConfig:
     """
     Tool and resource paths.

--- a/sftool/core/config.py
+++ b/sftool/core/config.py
@@ -5,28 +5,53 @@ Each class maps 1:1 to an existing top-level block
 in config_example.json. Internal structures are preserved
 exactly as provided.
 """
+from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Any
 from importlib.resources import files
+from pathlib import Path
 
 
 class Config:
     """
     Run-level configuration facade.
-
-    Aggregates all config block wrappers.
     """
 
-    def __init__(self, cfg: dict):
-        self.version = cfg.get("version",{})
+    def __init__(self, cfg: dict[str, Any]):
+        self.version = cfg.get("version", {})
         self.paths = PathsConfig(cfg.get("paths", {}))
-        self.references = ReferenceDataConfig(cfg.get("references", {}))
-        self.catalogs = CatalogConfig(cfg.get("catalogs", {}))
-        self.clinvar = ClinVarConfig(cfg.get("clinvar", {}))
-        self.smaca_thresholds = SMAcaConfig(cfg.get("smaca_thresholds", {}))
-        self.genebe_credentials = GeneBeConfig(cfg.get("genebe_credentials", {}))
+        self.resources = ResourceConfig(cfg.get("resources", {}))
+        self.references = ReferenceDataConfig(
+            cfg.get("references", {})
+        )
+        self.smaca_thresholds = SMAcaConfig(
+            cfg.get("smaca_thresholds", {})
+        )
+        self.genebe_credentials = GeneBeConfig(
+            cfg.get("genebe_credentials", {})
+        )
 
+class ResourceConfig:
+    """
+    Installed SFtool resource manifest configuration.
+    """
 
+    def __init__(self, cfg: dict[str, Any]):
+        manifest = cfg.get("manifest")
+
+        if not isinstance(manifest, str) or not manifest.strip():
+            raise ValueError(
+                "resources.manifest must be a non-empty path"
+            )
+
+        self.manifest: Path = (
+            Path(manifest)
+            .expanduser()
+            .resolve()
+        )
+
+        self.raw_manifest: dict[str, Any] | None = None
+        self.installed: dict[str, Any] | None = None
 
 class CatalogConfig:
     """
@@ -84,22 +109,43 @@ class SMAcaConfig:
 
 class ReferenceDataConfig:
     """
-    Reference-related resources, including:
-      - reference genomes
-      - gene-to-phenotype mappings
-      - pharmcat_positions_vcf
-    """
-    def __init__(self, cfg: dict):
-        categories_dir = files("sftool.data.categories")
+    User-provided reference genome overrides.
 
-        self.genomes: Dict = cfg.get("genomes", {})
-        self.gene_to_phenotype_file: Optional[str] = cfg.get(
-            "gene_to_phenotype_file",
-            categories_dir / "genes_to_phenotype_20260623.txt"
-        )
-        self.pharmCAT_positions_vcf: Optional[str] = cfg.get(
-            "pharmCAT_positions_vcf"
-        )
+    Missing and null entries mean that SFtool should try the installed
+    resource manifest.
+    """
+
+    def __init__(self, cfg: dict[str, Any]):
+        genomes = cfg.get("genomes", {})
+
+        if genomes is None:
+            genomes = {}
+
+        if not isinstance(genomes, dict):
+            raise ValueError(
+                "references.genomes must be an object"
+            )
+
+        self.genomes: dict[str, Path | None] = {}
+
+        for assembly in ("GRCh37", "GRCh38"):
+            value = genomes.get(assembly)
+
+            if value is None:
+                self.genomes[assembly] = None
+                continue
+
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(
+                    f"references.genomes.{assembly} must be "
+                    "a non-empty path or null"
+                )
+
+            self.genomes[assembly] = (
+                Path(value)
+                .expanduser()
+                .resolve()
+            )
 
 class PathsConfig:
     """
@@ -108,7 +154,6 @@ class PathsConfig:
     This maps to the top-level 'paths' block in config.json.
     """
     def __init__(self, cfg: dict):
-        self.categories = cfg["categories"]
         self.bcftools = cfg["bcftools"]
         self.java = cfg["java"]
         self.genebe = cfg["genebe"]

--- a/sftool/core/context.py
+++ b/sftool/core/context.py
@@ -10,6 +10,7 @@ from sftool.core.config import Config
 from sftool.variant_confirmation.models import (
     VariantConfirmationRequest
 )
+from sftool.core.resources import RuntimeResources
 
 
 class SampleContext:
@@ -125,12 +126,14 @@ class ExecutionContext:
         • run-level parameters
         • directory layout
         • configuration
+        • installed resources
     """
 
     def __init__(
             self,
             execution_meta: dict,
             config: Config,
+            resources: RuntimeResources,
             output_dir: str | Path,
             tmp_dir: str | Path | None = None,
     ):
@@ -144,20 +147,25 @@ class ExecutionContext:
         )
 
         # ------------------------------------------------------------------
-        # Configuration (run-level)
+        # Configuration and installed resources (run-level)
         # ------------------------------------------------------------------
         self.config: Config = config
+        self.resources: RuntimeResources = resources
 
         # ------------------------------------------------------------------
         # Run-level parameters
         # ------------------------------------------------------------------
-        self.assembly: Optional[str] = execution_meta.get("reference_genome")
-        self.modes: List[str] = execution_meta.get("modes",[])
-        self.clinvar_evidence: Optional[int] = execution_meta.get("clinvar_evidence")
-        self.variant_classification_sources: list[str] = execution_meta.get("variant_classification_sources")
+        self.assembly: Optional[str] = execution_meta.get(
+            "reference_genome"
+        )
+        self.modes: List[str] = execution_meta.get("modes", [])
+        self.clinvar_evidence: Optional[int] = execution_meta.get(
+            "clinvar_evidence"
+        )
+        self.variant_classification_sources: list[str] = (
+            execution_meta.get("variant_classification_sources")
+        )
         self.RR_mode: Optional[str] = execution_meta.get("RR_mode")
-
-
 
         # ------------------------------------------------------------------
         # Output directory layout
@@ -178,7 +186,10 @@ class ExecutionContext:
         # ------------------------------------------------------------------
         # Outputs populated during execution
         # ------------------------------------------------------------------
-        self.outputs: Dict[str, Dict[str, Dict[str, str | Path]]] = {
+        self.outputs: Dict[
+            str,
+            Dict[str, Dict[str, str | Path]],
+        ] = {
             "catalogs": {
                 "bed_files": {},
                 "json_files": {},
@@ -189,8 +200,8 @@ class ExecutionContext:
                 "clinvar_db_version": "",
                 "clinvar_db_assembly": "",
                 "PR_json": "",
-                "RR_json": ""
-            }
+                "RR_json": "",
+            },
         }
 
         # ------------------------------------------------------------------
@@ -201,10 +212,14 @@ class ExecutionContext:
     def add_sample(self, sample: SampleContext):
         self.samples.append(sample)
 
-    def get_sample(self, sample_id: str) -> Optional[SampleContext]:
+    def get_sample(
+            self,
+            sample_id: str,
+    ) -> Optional[SampleContext]:
         for sample in self.samples:
             if sample.sample_id == sample_id:
                 return sample
+
         return None
 
     def __repr__(self) -> str:

--- a/sftool/core/resources.py
+++ b/sftool/core/resources.py
@@ -56,6 +56,33 @@ class RuntimeResources:
     def reference_genome_source(self) -> str:
         return self.execution["reference_genome"]["source"]
 
+    @property
+    def hpo_file(self) -> Path:
+        return self.execution["hpo"]["file"]["path"]
+
+    @property
+    def hpo_version(self) -> str:
+        return self.execution["hpo"]["version"]
+
+    @property
+    def pharmcat_positions_vcf(self) -> Path:
+        return self.execution[
+            "pharmcat"
+        ]["positions_vcf"]["path"]
+
+    @property
+    def pharmcat_version(self) -> str:
+        return self.execution["pharmcat"]["version"]
+
+    @property
+    def rr_str_catalog(self) -> Path | None:
+        rr_str = self.execution.get("rr_str")
+
+        if rr_str is None:
+            return None
+
+        return rr_str["csv"]["path"]
+
 def load_resource_manifest(
         manifest_path: str | Path,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -930,8 +957,8 @@ def _validate_user_reference(
         "fasta": fasta,
         "fai": fai.resolve(),
         "source": "config",
-        "version": None,
-        "sha256": None,
+        "fasta_sha256": None,
+        "fai_sha256": None,
     }
 
 def _resolve_execution_reference(
@@ -958,8 +985,12 @@ def _resolve_execution_reference(
             "fasta": installed_reference["fasta"]["path"],
             "fai": installed_reference["fai"]["path"],
             "source": "manifest",
-            "version": installed_reference.get("version"),
-            "sha256": installed_reference["fasta"].get("sha256"),
+            "fasta_sha256": (
+                installed_reference["fasta"]["sha256"]
+            ),
+            "fai_sha256": (
+                installed_reference["fai"]["sha256"]
+            ),
         }
 
     raise ResourceManifestError(
@@ -982,6 +1013,35 @@ def resolve_execution_resources(
             f"Unsupported assembly: {assembly}"
         )
 
+    if (
+            not isinstance(clinvar_evidence, int)
+            or isinstance(clinvar_evidence, bool)
+            or clinvar_evidence
+            not in SUPPORTED_CLINVAR_EVIDENCE_LEVELS
+    ):
+        supported = ", ".join(
+            str(level)
+            for level in sorted(
+                SUPPORTED_CLINVAR_EVIDENCE_LEVELS
+            )
+        )
+
+        raise ResourceManifestError(
+            f"Unsupported ClinVar evidence level: "
+            f"{clinvar_evidence!r}. "
+            f"Supported levels are: {supported}."
+        )
+
+    unsupported_categories = (
+            set(categories) - SUPPORTED_CATALOGS
+    )
+
+    if unsupported_categories:
+        raise ResourceManifestError(
+            "Unsupported resource category or categories: "
+            + ", ".join(sorted(unsupported_categories))
+        )
+
     assembly_catalogs = (
         installed["catalogs"]
         ["assemblies"]
@@ -990,19 +1050,8 @@ def resolve_execution_resources(
 
     if assembly_catalogs is None:
         raise ResourceManifestError(
-            f"No installed catalogs are available for {assembly}"
-        )
-
-    clinvar_database = (
-        installed["clinvar"]
-        ["databases"]
-        .get(assembly)
-    )
-
-    if clinvar_database is None:
-        raise ResourceManifestError(
-            f"No installed ClinVar database is "
-            f"available for {assembly}"
+            f"No installed catalogs are available for "
+            f"{assembly}"
         )
 
     clinvar_filtered_databases = (
@@ -1013,17 +1062,14 @@ def resolve_execution_resources(
 
     if clinvar_filtered_databases is None:
         raise ResourceManifestError(
-            f"No installed filtered ClinVar resources are "
-            f"available for {assembly}"
+            f"No installed filtered ClinVar resources "
+            f"are available for {assembly}"
         )
 
     selected_catalogs: dict[str, Any] = {}
     selected_clinvar: dict[str, Any] = {}
 
     for category in sorted(categories):
-        if category not in SUPPORTED_CATALOGS:
-            continue
-
         catalog = assembly_catalogs.get(category)
 
         if catalog is None:
@@ -1034,33 +1080,55 @@ def resolve_execution_resources(
 
         selected_catalogs[category] = catalog
 
-        evidence_files = clinvar_filtered_databases.get(
-            category,
-            {},
+        evidence_files = (
+            clinvar_filtered_databases.get(category)
         )
 
-        clinvar_file = evidence_files.get(clinvar_evidence)
+        if evidence_files is None:
+            raise ResourceManifestError(
+                f"No installed ClinVar resources are "
+                f"available for assembly={assembly}, "
+                f"catalog={category}"
+            )
+
+        clinvar_file = evidence_files.get(
+            clinvar_evidence
+        )
 
         if clinvar_file is None:
             raise ResourceManifestError(
-                f"No installed ClinVar resource is available "
-                f"for assembly={assembly}, "
+                f"No installed ClinVar resource is "
+                f"available for assembly={assembly}, "
                 f"catalog={category}, "
                 f"evidence={clinvar_evidence}"
             )
 
         selected_clinvar[category] = clinvar_file
 
+    rr_str = None
+
+    if "RR" in categories:
+        rr_str = installed["catalogs"].get("RR_STR")
+
+        if rr_str is None:
+            raise ResourceManifestError(
+                "The installed resource bundle does not "
+                "contain the RR-STR catalog required for "
+                "RR analysis"
+            )
+
     return {
+        "assembly": assembly,
         "reference_genome": _resolve_execution_reference(
             assembly=assembly,
             configured_genomes=configured_genomes,
-            installed_references=installed["reference_genomes"],
+            installed_references=(
+                installed["reference_genomes"]
+            ),
         ),
         "catalogs": selected_catalogs,
         "clinvar": selected_clinvar,
-        "clinvar_database": clinvar_database,
-        "rr_str": installed["catalogs"]["RR_STR"],
+        "rr_str": rr_str,
         "hpo": installed["hpo"],
         "pharmcat": installed["pharmcat"],
     }
@@ -1077,7 +1145,71 @@ def get_required_resource_categories(
         category
         for sample in samples_info["samples"]
         for category in sample.get("categories", [])
-        if category in {"PR", "RR"}
+        if category in SUPPORTED_CATALOGS
     }
 
     return required
+
+def clinvar_file(
+        self,
+        category: str,
+) -> Path:
+    descriptor = self.execution[
+        "clinvar"
+    ].get(category)
+
+    if descriptor is None:
+        raise ResourceManifestError(
+            f"No ClinVar resource was selected for "
+            f"category {category}"
+        )
+
+    return descriptor["path"]
+
+def catalog_json(
+        self,
+        category: str,
+) -> Path:
+    catalog = self.execution[
+        "catalogs"
+    ].get(category)
+
+    if catalog is None:
+        raise ResourceManifestError(
+            f"No catalog resource was selected for "
+            f"category {category}"
+        )
+
+    return catalog["json"]["path"]
+
+def catalog_bed(
+        self,
+        category: str,
+) -> Path:
+    catalog = self.execution[
+        "catalogs"
+    ].get(category)
+
+    if catalog is None:
+        raise ResourceManifestError(
+            f"No catalog resource was selected for "
+            f"category {category}"
+        )
+
+    return catalog["bed"]["path"]
+
+def catalog_chr_bed(
+        self,
+        category: str,
+) -> Path:
+    catalog = self.execution[
+        "catalogs"
+    ].get(category)
+
+    if catalog is None:
+        raise ResourceManifestError(
+            f"No catalog resource was selected for "
+            f"category {category}"
+        )
+
+    return catalog["chr_bed"]["path"]

--- a/sftool/core/resources.py
+++ b/sftool/core/resources.py
@@ -7,6 +7,10 @@ from typing import Any
 
 from sftool.utils.errors import ResourceManifestError
 
+from sftool.utils.checksums import (
+    ChecksumError,
+    calculate_sha256,
+)
 
 SUPPORTED_MANIFEST_SCHEMA_VERSIONS = {2}
 SUPPORTED_ASSEMBLIES = {"GRCh37", "GRCh38"}
@@ -100,6 +104,194 @@ def load_resource_manifest(
         manifest=manifest,
         root=root,
     )
+
+    return manifest, installed
+
+def _validate_resource_checksum(
+        descriptor: dict[str, Any],
+        *,
+        label: str,
+) -> None:
+    """
+    Verify one resolved manifest file descriptor.
+    """
+    path = descriptor["path"]
+    expected_checksum = descriptor["sha256"]
+
+    try:
+        actual_checksum = calculate_sha256(path)
+    except ChecksumError as exc:
+        raise ResourceManifestError(
+            f"Could not verify installed resource "
+            f"{label}: {path}. "
+            "Ensure the file is readable or reinstall the "
+            "resource bundle with 'sftool resources setup'."
+        ) from exc
+
+    if actual_checksum != expected_checksum:
+        raise ResourceManifestError(
+            f"Checksum mismatch for installed resource "
+            f"{label}: {path}. "
+            f"Expected SHA-256 {expected_checksum}, "
+            f"found {actual_checksum}. "
+            "The resource file may be corrupted or modified. "
+            "Run 'sftool resources setup' again using the "
+            "same resource directory."
+        )
+
+def _validate_required_resource_checksums(
+        installed: dict[str, Any],
+) -> None:
+    catalogs = installed["catalogs"]
+
+    _validate_resource_checksum(
+        catalogs["RR_STR"]["csv"],
+        label="datasets.catalogs.RR_STR.csv",
+    )
+
+    for assembly in sorted(SUPPORTED_ASSEMBLIES):
+        assembly_catalogs = (
+            catalogs["assemblies"][assembly]
+        )
+
+        for catalog_name in sorted(SUPPORTED_CATALOGS):
+            catalog = assembly_catalogs[catalog_name]
+
+            for file_type in ("bed", "chr_bed", "json"):
+                _validate_resource_checksum(
+                    catalog[file_type],
+                    label=(
+                        "datasets.catalogs.assemblies."
+                        f"{assembly}.{catalog_name}."
+                        f"{file_type}"
+                    ),
+                )
+
+    clinvar = installed["clinvar"]
+
+    for source_name in (
+            "variant_summary",
+            "submission_summary",
+    ):
+        _validate_resource_checksum(
+            clinvar["source_files"][source_name],
+            label=(
+                "datasets.clinvar.source_files."
+                f"{source_name}"
+            ),
+        )
+
+    for assembly in sorted(SUPPORTED_ASSEMBLIES):
+        _validate_resource_checksum(
+            clinvar["databases"][assembly],
+            label=(
+                f"datasets.clinvar.databases.{assembly}"
+            ),
+        )
+
+        for catalog_name in sorted(SUPPORTED_CATALOGS):
+            evidence_resources = (
+                clinvar["filtered_databases"]
+                [assembly][catalog_name]
+            )
+
+            for evidence in sorted(
+                    SUPPORTED_CLINVAR_EVIDENCE_LEVELS
+            ):
+                _validate_resource_checksum(
+                    evidence_resources[evidence],
+                    label=(
+                        "datasets.clinvar."
+                        "filtered_databases."
+                        f"{assembly}.{catalog_name}."
+                        f"{evidence}"
+                    ),
+                )
+
+    _validate_resource_checksum(
+        installed["hpo"]["file"],
+        label="datasets.hpo.file",
+    )
+
+    _validate_resource_checksum(
+        installed["pharmcat"]["positions_vcf"],
+        label="datasets.pharmcat.positions_vcf",
+    )
+
+def _validate_optional_reference_checksums(
+        installed: dict[str, Any],
+) -> None:
+    references = installed["reference_genomes"]
+
+    for assembly in sorted(SUPPORTED_ASSEMBLIES):
+        reference = references[assembly]
+
+        if reference is None:
+            continue
+
+        _validate_resource_checksum(
+            reference["fasta"],
+            label=(
+                "datasets.reference_genomes."
+                f"{assembly}.fasta"
+            ),
+        )
+
+        _validate_resource_checksum(
+            reference["fai"],
+            label=(
+                "datasets.reference_genomes."
+                f"{assembly}.fai"
+            ),
+        )
+
+def _validate_installed_resource_checksums(
+        installed: dict[str, Any],
+) -> None:
+    """
+    Verify all files registered in an installed bundle.
+    """
+    _validate_required_resource_checksums(
+        installed
+    )
+    _validate_optional_reference_checksums(
+        installed
+    )
+
+def validate_resource_bundle(
+        manifest_path: str | Path,
+        *,
+        verify_checksums: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Load and validate an installed SFtool resource bundle.
+
+    Validation includes:
+
+    - manifest JSON and schema compatibility;
+    - required manifest structure;
+    - installation-root resolution;
+    - relative-path containment;
+    - presence of every manifest-referenced file;
+    - SHA-256 integrity verification when enabled.
+
+    Returns:
+        A tuple containing the raw manifest and the
+        runtime-normalized installed-resource structure.
+
+    Raises:
+        ResourceManifestError:
+            If the resource bundle is incompatible,
+            incomplete or corrupted.
+    """
+    manifest, installed = load_resource_manifest(
+        manifest_path
+    )
+
+    if verify_checksums:
+        _validate_installed_resource_checksums(
+            installed
+        )
 
     return manifest, installed
 

--- a/sftool/core/resources.py
+++ b/sftool/core/resources.py
@@ -414,46 +414,43 @@ def _validate_clinvar_manifest(clinvar: Any) -> None:
             label=f"datasets.clinvar.source_files.{source_name}",
         )
 
-    assemblies = clinvar.get("assemblies")
+    databases = clinvar.get("databases")
 
-    if not isinstance(assemblies, dict):
+    if not isinstance(databases, dict):
         raise ResourceManifestError(
-            "datasets.clinvar.assemblies must be an object"
+            "datasets.clinvar.databases must be an object"
+        )
+
+    filtered_databases = clinvar.get("filtered_databases")
+
+    if not isinstance(filtered_databases, dict):
+        raise ResourceManifestError(
+            "datasets.clinvar.filtered_databases must be an object"
         )
 
     for assembly in SUPPORTED_ASSEMBLIES:
-        assembly_data = assemblies.get(assembly)
-
-        if not isinstance(assembly_data, dict):
-            raise ResourceManifestError(
-                f"datasets.clinvar.assemblies.{assembly} "
-                "must be an object"
-            )
-
         _validate_file_descriptor(
-            assembly_data.get("database"),
-            label=(
-                f"datasets.clinvar.assemblies."
-                f"{assembly}.database"
-            ),
+            databases.get(assembly),
+            label=f"datasets.clinvar.databases.{assembly}",
         )
 
-        catalogs = assembly_data.get("catalogs")
+        assembly_filtered_databases = filtered_databases.get(assembly)
 
-        if not isinstance(catalogs, dict):
+        if not isinstance(assembly_filtered_databases, dict):
             raise ResourceManifestError(
-                f"datasets.clinvar.assemblies."
-                f"{assembly}.catalogs must be an object"
+                f"datasets.clinvar.filtered_databases."
+                f"{assembly} must be an object"
             )
 
         for catalog_name in SUPPORTED_CATALOGS:
-            evidence_files = catalogs.get(catalog_name)
+            evidence_files = assembly_filtered_databases.get(
+                catalog_name
+            )
 
             if not isinstance(evidence_files, dict):
                 raise ResourceManifestError(
-                    f"datasets.clinvar.assemblies."
-                    f"{assembly}.catalogs.{catalog_name} "
-                    "must be an object"
+                    f"datasets.clinvar.filtered_databases."
+                    f"{assembly}.{catalog_name} must be an object"
                 )
 
             actual_levels = set()
@@ -464,7 +461,8 @@ def _validate_clinvar_manifest(clinvar: Any) -> None:
                 except (TypeError, ValueError) as exc:
                     raise ResourceManifestError(
                         f"Invalid ClinVar evidence key "
-                        f"{level_key!r} for {assembly}/{catalog_name}"
+                        f"{level_key!r} for "
+                        f"{assembly}/{catalog_name}"
                     ) from exc
 
                 actual_levels.add(level)
@@ -472,9 +470,8 @@ def _validate_clinvar_manifest(clinvar: Any) -> None:
                 _validate_file_descriptor(
                     descriptor,
                     label=(
-                        f"datasets.clinvar.assemblies."
-                        f"{assembly}.catalogs."
-                        f"{catalog_name}.{level_key}"
+                        f"datasets.clinvar.filtered_databases."
+                        f"{assembly}.{catalog_name}.{level_key}"
                     ),
                 )
 
@@ -487,6 +484,7 @@ def _validate_clinvar_manifest(clinvar: Any) -> None:
                     f"found {sorted(actual_levels)}"
                 )
 
+
 def _resolve_clinvar(
         clinvar: dict[str, Any],
         *,
@@ -495,7 +493,8 @@ def _resolve_clinvar(
     resolved: dict[str, Any] = {
         "version": clinvar["version"],
         "source_files": {},
-        "assemblies": {},
+        "databases": {},
+        "filtered_databases": {},
     }
 
     for source_name, descriptor in clinvar["source_files"].items():
@@ -505,36 +504,32 @@ def _resolve_clinvar(
             label=f"datasets.clinvar.source_files.{source_name}",
         )
 
-    for assembly, assembly_data in clinvar["assemblies"].items():
-        resolved_assembly = {
-            "database": _resolve_descriptor(
-                assembly_data["database"],
-                root=root,
-                label=(
-                    f"datasets.clinvar.assemblies."
-                    f"{assembly}.database"
-                ),
-            ),
-            "catalogs": {},
-        }
+    for assembly, descriptor in clinvar["databases"].items():
+        resolved["databases"][assembly] = _resolve_descriptor(
+            descriptor,
+            root=root,
+            label=f"datasets.clinvar.databases.{assembly}",
+        )
+
+    for assembly, assembly_databases in (
+            clinvar["filtered_databases"].items()
+    ):
+        resolved["filtered_databases"][assembly] = {}
 
         for catalog_name, evidence_files in (
-                assembly_data["catalogs"].items()
+                assembly_databases.items()
         ):
-            resolved_assembly["catalogs"][catalog_name] = {
+            resolved["filtered_databases"][assembly][catalog_name] = {
                 int(level): _resolve_descriptor(
                     descriptor,
                     root=root,
                     label=(
-                        f"datasets.clinvar.assemblies."
-                        f"{assembly}.catalogs."
-                        f"{catalog_name}.{level}"
+                        f"datasets.clinvar.filtered_databases."
+                        f"{assembly}.{catalog_name}.{level}"
                     ),
                 )
                 for level, descriptor in evidence_files.items()
             }
-
-        resolved["assemblies"][assembly] = resolved_assembly
 
     return resolved
 
@@ -810,15 +805,27 @@ def resolve_execution_resources(
             f"No installed catalogs are available for {assembly}"
         )
 
-    clinvar_assembly = (
+    clinvar_database = (
         installed["clinvar"]
-        ["assemblies"]
+        ["databases"]
         .get(assembly)
     )
 
-    if clinvar_assembly is None:
+    if clinvar_database is None:
         raise ResourceManifestError(
-            f"No installed ClinVar resources are "
+            f"No installed ClinVar database is "
+            f"available for {assembly}"
+        )
+
+    clinvar_filtered_databases = (
+        installed["clinvar"]
+        ["filtered_databases"]
+        .get(assembly)
+    )
+
+    if clinvar_filtered_databases is None:
+        raise ResourceManifestError(
+            f"No installed filtered ClinVar resources are "
             f"available for {assembly}"
         )
 
@@ -839,9 +846,9 @@ def resolve_execution_resources(
 
         selected_catalogs[category] = catalog
 
-        evidence_files = (
-            clinvar_assembly["catalogs"]
-            .get(category, {})
+        evidence_files = clinvar_filtered_databases.get(
+            category,
+            {},
         )
 
         clinvar_file = evidence_files.get(clinvar_evidence)
@@ -864,7 +871,7 @@ def resolve_execution_resources(
         ),
         "catalogs": selected_catalogs,
         "clinvar": selected_clinvar,
-        "clinvar_database": clinvar_assembly["database"],
+        "clinvar_database": clinvar_database,
         "rr_str": installed["catalogs"]["RR_STR"],
         "hpo": installed["hpo"],
         "pharmcat": installed["pharmcat"],

--- a/sftool/core/resources.py
+++ b/sftool/core/resources.py
@@ -1,0 +1,888 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from sftool.utils.errors import ResourceManifestError
+
+
+SUPPORTED_MANIFEST_SCHEMA_VERSIONS = {2}
+SUPPORTED_ASSEMBLIES = {"GRCh37", "GRCh38"}
+SUPPORTED_CATALOGS = {"PR", "RR"}
+SUPPORTED_CLINVAR_EVIDENCE_LEVELS = {1, 2, 3, 4}
+
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+class RuntimeResources:
+    """
+    Installed resources resolved for one SFtool execution.
+
+    The original manifest remains available for provenance, while resource
+    paths are exposed as pathlib.Path objects.
+    """
+
+    def __init__(
+            self,
+            *,
+            manifest_path: Path,
+            manifest: dict[str, Any],
+            installed: dict[str, Any],
+            execution: dict[str, Any],
+    ):
+        self.manifest_path = manifest_path
+        self.manifest = manifest
+        self.installed = installed
+        self.execution = execution
+
+    @property
+    def root(self) -> Path:
+        return self.installed["root"]
+
+    @property
+    def reference_genome(self) -> Path:
+        return self.execution["reference_genome"]["fasta"]
+
+    @property
+    def reference_genome_index(self) -> Path:
+        return self.execution["reference_genome"]["fai"]
+
+    @property
+    def reference_genome_source(self) -> str:
+        return self.execution["reference_genome"]["source"]
+
+def load_resource_manifest(
+        manifest_path: str | Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """
+    Load, validate and resolve an installed SFtool resource manifest.
+
+    Returns:
+        raw_manifest:
+            Original JSON-compatible manifest.
+
+        installed_resources:
+            Runtime-normalized resource structure containing absolute Paths.
+    """
+    path = Path(manifest_path).expanduser().resolve()
+
+    if not path.exists():
+        raise ResourceManifestError(
+            f"Resource manifest not found: {path}"
+        )
+
+    if not path.is_file():
+        raise ResourceManifestError(
+            f"Resource manifest is not a file: {path}"
+        )
+
+    try:
+        with path.open(encoding="utf-8") as handle:
+            manifest = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ResourceManifestError(
+            f"Invalid JSON in resource manifest {path}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise ResourceManifestError(
+            f"Could not read resource manifest {path}: {exc}"
+        ) from exc
+
+    _validate_manifest_structure(manifest, manifest_path=path)
+
+    root = _resolve_resources_root(
+        manifest=manifest,
+        manifest_path=path,
+    )
+
+    installed = _resolve_installed_resources(
+        manifest=manifest,
+        root=root,
+    )
+
+    return manifest, installed
+
+def _resolve_resources_root(
+        *,
+        manifest: dict[str, Any],
+        manifest_path: Path,
+) -> Path:
+    resources_root_value = manifest.get("resources_root", ".")
+
+    if not isinstance(resources_root_value, str):
+        raise ResourceManifestError(
+            "Manifest field 'resources_root' must be a string"
+        )
+
+    configured_root = Path(resources_root_value).expanduser()
+
+    if configured_root.is_absolute():
+        root = configured_root.resolve()
+    else:
+        root = (manifest_path.parent / configured_root).resolve()
+
+    if not root.exists():
+        raise ResourceManifestError(
+            f"Resource installation root does not exist: {root}"
+        )
+
+    if not root.is_dir():
+        raise ResourceManifestError(
+            f"Resource installation root is not a directory: {root}"
+        )
+
+    return root
+
+def _validate_manifest_structure(
+        manifest: Any,
+        *,
+        manifest_path: Path,
+) -> None:
+    if not isinstance(manifest, dict):
+        raise ResourceManifestError(
+            f"Resource manifest must contain a JSON object: {manifest_path}"
+        )
+
+    schema_version = manifest.get("schema_version")
+
+    if schema_version not in SUPPORTED_MANIFEST_SCHEMA_VERSIONS:
+        supported = ", ".join(
+            str(version)
+            for version in sorted(SUPPORTED_MANIFEST_SCHEMA_VERSIONS)
+        )
+
+        raise ResourceManifestError(
+            f"Unsupported resource manifest schema version "
+            f"{schema_version!r} in {manifest_path}. "
+            f"Supported version(s): {supported}."
+        )
+
+    datasets = manifest.get("datasets")
+
+    if not isinstance(datasets, dict):
+        raise ResourceManifestError(
+            "Manifest field 'datasets' must be an object"
+        )
+
+    required_datasets = {
+        "catalogs",
+        "clinvar",
+        "hpo",
+        "pharmcat",
+    }
+
+    missing = required_datasets - datasets.keys()
+
+    if missing:
+        raise ResourceManifestError(
+            "Resource manifest is missing required dataset block(s): "
+            + ", ".join(sorted(missing))
+        )
+
+    _validate_catalog_manifest(datasets["catalogs"])
+    _validate_clinvar_manifest(datasets["clinvar"])
+    _validate_single_file_dataset("hpo", datasets["hpo"])
+    _validate_single_file_dataset("pharmcat", datasets["pharmcat"])
+    _validate_reference_manifest(
+        datasets.get("reference_genomes")
+    )
+
+def _validate_file_descriptor(
+        descriptor: Any,
+        *,
+        label: str,
+) -> None:
+    if not isinstance(descriptor, dict):
+        raise ResourceManifestError(
+            f"{label} must be an object"
+        )
+
+    path_value = descriptor.get("path")
+
+    if not isinstance(path_value, str) or not path_value.strip():
+        raise ResourceManifestError(
+            f"{label}.path must be a non-empty string"
+        )
+
+    checksum = descriptor.get("sha256")
+
+    if not isinstance(checksum, str):
+        raise ResourceManifestError(
+            f"{label}.sha256 must be a string"
+        )
+
+    if not _SHA256_PATTERN.fullmatch(checksum):
+        raise ResourceManifestError(
+            f"{label}.sha256 is not a valid lowercase SHA-256 digest"
+        )
+
+    source_url = descriptor.get("source_url")
+
+    if source_url is not None and (
+            not isinstance(source_url, str)
+            or not source_url.strip()
+    ):
+        raise ResourceManifestError(
+            f"{label}.source_url must be a non-empty string when provided"
+        )
+
+def _resolve_descriptor(
+        descriptor: dict[str, Any],
+        *,
+        root: Path,
+        label: str,
+        require_file: bool = True,
+) -> dict[str, Any]:
+    _validate_file_descriptor(
+        descriptor,
+        label=label,
+    )
+
+    relative_path = Path(descriptor["path"])
+
+    if relative_path.is_absolute():
+        raise ResourceManifestError(
+            f"{label}.path must be relative to the resource root: "
+            f"{relative_path}"
+        )
+
+    absolute_path = (root / relative_path).resolve()
+
+    try:
+        absolute_path.relative_to(root)
+    except ValueError as exc:
+        raise ResourceManifestError(
+            f"{label}.path escapes the resource installation root: "
+            f"{relative_path}"
+        ) from exc
+
+    if require_file:
+        if not absolute_path.exists():
+            raise ResourceManifestError(
+                f"Installed resource file does not exist for {label}: "
+                f"{absolute_path}"
+            )
+
+        if not absolute_path.is_file():
+            raise ResourceManifestError(
+                f"Installed resource path is not a file for {label}: "
+                f"{absolute_path}"
+            )
+
+    resolved = dict(descriptor)
+    resolved["path"] = absolute_path
+
+    return resolved
+
+def _validate_catalog_manifest(catalogs: Any) -> None:
+    if not isinstance(catalogs, dict):
+        raise ResourceManifestError(
+            "datasets.catalogs must be an object"
+        )
+
+    rr_str = catalogs.get("RR_STR")
+
+    if not isinstance(rr_str, dict):
+        raise ResourceManifestError(
+            "datasets.catalogs.RR_STR must be an object"
+        )
+
+    _validate_version(
+        rr_str.get("version"),
+        label="datasets.catalogs.RR_STR.version",
+    )
+
+    _validate_file_descriptor(
+        rr_str.get("csv"),
+        label="datasets.catalogs.RR_STR.csv",
+    )
+
+    assemblies = catalogs.get("assemblies")
+
+    if not isinstance(assemblies, dict):
+        raise ResourceManifestError(
+            "datasets.catalogs.assemblies must be an object"
+        )
+
+    for assembly in SUPPORTED_ASSEMBLIES:
+        assembly_catalogs = assemblies.get(assembly)
+
+        if not isinstance(assembly_catalogs, dict):
+            raise ResourceManifestError(
+                f"datasets.catalogs.assemblies.{assembly} "
+                "must be an object"
+            )
+
+        for catalog_name in SUPPORTED_CATALOGS:
+            catalog = assembly_catalogs.get(catalog_name)
+
+            if not isinstance(catalog, dict):
+                raise ResourceManifestError(
+                    f"datasets.catalogs.assemblies."
+                    f"{assembly}.{catalog_name} must be an object"
+                )
+
+            _validate_version(
+                catalog.get("version"),
+                label=(
+                    f"datasets.catalogs.assemblies."
+                    f"{assembly}.{catalog_name}.version"
+                ),
+            )
+
+            for file_type in ("bed", "chr_bed", "json"):
+                _validate_file_descriptor(
+                    catalog.get(file_type),
+                    label=(
+                        f"datasets.catalogs.assemblies."
+                        f"{assembly}.{catalog_name}.{file_type}"
+                    ),
+                )
+
+def _validate_version(value: Any, *, label: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ResourceManifestError(
+            f"{label} must be a non-empty string"
+        )
+
+def _resolve_catalogs(
+        catalogs: dict[str, Any],
+        *,
+        root: Path,
+) -> dict[str, Any]:
+    resolved: dict[str, Any] = {
+        "RR_STR": {
+            "version": catalogs["RR_STR"]["version"],
+            "csv": _resolve_descriptor(
+                catalogs["RR_STR"]["csv"],
+                root=root,
+                label="datasets.catalogs.RR_STR.csv",
+            ),
+        },
+        "assemblies": {},
+    }
+
+    for assembly, assembly_catalogs in catalogs["assemblies"].items():
+        resolved["assemblies"][assembly] = {}
+
+        for catalog_name, catalog in assembly_catalogs.items():
+            resolved_catalog = {
+                "version": catalog["version"],
+            }
+
+            for file_type in ("bed", "chr_bed", "json"):
+                resolved_catalog[file_type] = _resolve_descriptor(
+                    catalog[file_type],
+                    root=root,
+                    label=(
+                        f"datasets.catalogs.assemblies."
+                        f"{assembly}.{catalog_name}.{file_type}"
+                    ),
+                )
+
+            resolved["assemblies"][assembly][catalog_name] = (
+                resolved_catalog
+            )
+
+    return resolved
+
+def _validate_clinvar_manifest(clinvar: Any) -> None:
+    if not isinstance(clinvar, dict):
+        raise ResourceManifestError(
+            "datasets.clinvar must be an object"
+        )
+
+    _validate_version(
+        clinvar.get("version"),
+        label="datasets.clinvar.version",
+    )
+
+    source_files = clinvar.get("source_files")
+
+    if not isinstance(source_files, dict):
+        raise ResourceManifestError(
+            "datasets.clinvar.source_files must be an object"
+        )
+
+    for source_name in (
+            "variant_summary",
+            "submission_summary",
+    ):
+        _validate_file_descriptor(
+            source_files.get(source_name),
+            label=f"datasets.clinvar.source_files.{source_name}",
+        )
+
+    assemblies = clinvar.get("assemblies")
+
+    if not isinstance(assemblies, dict):
+        raise ResourceManifestError(
+            "datasets.clinvar.assemblies must be an object"
+        )
+
+    for assembly in SUPPORTED_ASSEMBLIES:
+        assembly_data = assemblies.get(assembly)
+
+        if not isinstance(assembly_data, dict):
+            raise ResourceManifestError(
+                f"datasets.clinvar.assemblies.{assembly} "
+                "must be an object"
+            )
+
+        _validate_file_descriptor(
+            assembly_data.get("database"),
+            label=(
+                f"datasets.clinvar.assemblies."
+                f"{assembly}.database"
+            ),
+        )
+
+        catalogs = assembly_data.get("catalogs")
+
+        if not isinstance(catalogs, dict):
+            raise ResourceManifestError(
+                f"datasets.clinvar.assemblies."
+                f"{assembly}.catalogs must be an object"
+            )
+
+        for catalog_name in SUPPORTED_CATALOGS:
+            evidence_files = catalogs.get(catalog_name)
+
+            if not isinstance(evidence_files, dict):
+                raise ResourceManifestError(
+                    f"datasets.clinvar.assemblies."
+                    f"{assembly}.catalogs.{catalog_name} "
+                    "must be an object"
+                )
+
+            actual_levels = set()
+
+            for level_key, descriptor in evidence_files.items():
+                try:
+                    level = int(level_key)
+                except (TypeError, ValueError) as exc:
+                    raise ResourceManifestError(
+                        f"Invalid ClinVar evidence key "
+                        f"{level_key!r} for {assembly}/{catalog_name}"
+                    ) from exc
+
+                actual_levels.add(level)
+
+                _validate_file_descriptor(
+                    descriptor,
+                    label=(
+                        f"datasets.clinvar.assemblies."
+                        f"{assembly}.catalogs."
+                        f"{catalog_name}.{level_key}"
+                    ),
+                )
+
+            if actual_levels != SUPPORTED_CLINVAR_EVIDENCE_LEVELS:
+                raise ResourceManifestError(
+                    f"ClinVar resources for "
+                    f"{assembly}/{catalog_name} must provide "
+                    f"evidence levels "
+                    f"{sorted(SUPPORTED_CLINVAR_EVIDENCE_LEVELS)}; "
+                    f"found {sorted(actual_levels)}"
+                )
+
+def _resolve_clinvar(
+        clinvar: dict[str, Any],
+        *,
+        root: Path,
+) -> dict[str, Any]:
+    resolved: dict[str, Any] = {
+        "version": clinvar["version"],
+        "source_files": {},
+        "assemblies": {},
+    }
+
+    for source_name, descriptor in clinvar["source_files"].items():
+        resolved["source_files"][source_name] = _resolve_descriptor(
+            descriptor,
+            root=root,
+            label=f"datasets.clinvar.source_files.{source_name}",
+        )
+
+    for assembly, assembly_data in clinvar["assemblies"].items():
+        resolved_assembly = {
+            "database": _resolve_descriptor(
+                assembly_data["database"],
+                root=root,
+                label=(
+                    f"datasets.clinvar.assemblies."
+                    f"{assembly}.database"
+                ),
+            ),
+            "catalogs": {},
+        }
+
+        for catalog_name, evidence_files in (
+                assembly_data["catalogs"].items()
+        ):
+            resolved_assembly["catalogs"][catalog_name] = {
+                int(level): _resolve_descriptor(
+                    descriptor,
+                    root=root,
+                    label=(
+                        f"datasets.clinvar.assemblies."
+                        f"{assembly}.catalogs."
+                        f"{catalog_name}.{level}"
+                    ),
+                )
+                for level, descriptor in evidence_files.items()
+            }
+
+        resolved["assemblies"][assembly] = resolved_assembly
+
+    return resolved
+
+def _validate_single_file_dataset(
+        dataset_name: str,
+        dataset: Any,
+) -> None:
+    if not isinstance(dataset, dict):
+        raise ResourceManifestError(
+            f"datasets.{dataset_name} must be an object"
+        )
+
+    _validate_version(
+        dataset.get("version"),
+        label=f"datasets.{dataset_name}.version",
+    )
+
+    descriptor_key = _find_single_descriptor_key(
+        dataset_name,
+        dataset,
+    )
+
+    _validate_file_descriptor(
+        dataset.get(descriptor_key),
+        label=f"datasets.{dataset_name}.{descriptor_key}",
+    )
+
+def _resolve_hpo(
+        hpo: dict[str, Any],
+        *,
+        root: Path,
+) -> dict[str, Any]:
+    return {
+        "version": hpo["version"],
+        "gene_to_phenotype": _resolve_descriptor(
+            hpo["gene_to_phenotype"],
+            root=root,
+            label="datasets.hpo.gene_to_phenotype",
+        ),
+    }
+
+
+def _resolve_pharmcat(
+        pharmcat: dict[str, Any],
+        *,
+        root: Path,
+) -> dict[str, Any]:
+    return {
+        "version": pharmcat["version"],
+        "positions": _resolve_descriptor(
+            pharmcat["positions"],
+            root=root,
+            label="datasets.pharmcat.positions",
+        ),
+    }
+
+def _validate_reference_manifest(
+        references: Any,
+) -> None:
+    if references is None:
+        return
+
+    if not isinstance(references, dict):
+        raise ResourceManifestError(
+            "datasets.reference_genomes must be "
+            "an object or null"
+        )
+
+    unexpected = set(references) - SUPPORTED_ASSEMBLIES
+
+    if unexpected:
+        raise ResourceManifestError(
+            "Unsupported reference genome assembly key(s): "
+            + ", ".join(sorted(unexpected))
+        )
+
+    for assembly in SUPPORTED_ASSEMBLIES:
+        reference = references.get(assembly)
+
+        if reference is None:
+            continue
+
+        if not isinstance(reference, dict):
+            raise ResourceManifestError(
+                f"datasets.reference_genomes.{assembly} "
+                "must be an object or null"
+            )
+
+        _validate_file_descriptor(
+            reference.get("fasta"),
+            label=(
+                f"datasets.reference_genomes."
+                f"{assembly}.fasta"
+            ),
+        )
+
+        _validate_file_descriptor(
+            reference.get("fai"),
+            label=(
+                f"datasets.reference_genomes."
+                f"{assembly}.fai"
+            ),
+        )
+
+def _resolve_reference_genomes(
+        references: dict[str, Any] | None,
+        *,
+        root: Path,
+) -> dict[str, dict[str, Any] | None]:
+    references = references or {}
+
+    resolved: dict[str, dict[str, Any] | None] = {}
+
+    for assembly in SUPPORTED_ASSEMBLIES:
+        reference = references.get(assembly)
+
+        if reference is None:
+            resolved[assembly] = None
+            continue
+
+        resolved[assembly] = {
+            "fasta": _resolve_descriptor(
+                reference["fasta"],
+                root=root,
+                label=(
+                    f"datasets.reference_genomes."
+                    f"{assembly}.fasta"
+                ),
+            ),
+            "fai": _resolve_descriptor(
+                reference["fai"],
+                root=root,
+                label=(
+                    f"datasets.reference_genomes."
+                    f"{assembly}.fai"
+                ),
+            ),
+        }
+
+    return resolved
+
+def _resolve_installed_resources(
+        *,
+        manifest: dict[str, Any],
+        root: Path,
+) -> dict[str, Any]:
+    datasets = manifest["datasets"]
+
+    return {
+        "root": root,
+        "catalogs": _resolve_catalogs(
+            datasets["catalogs"],
+            root=root,
+        ),
+        "clinvar": _resolve_clinvar(
+            datasets["clinvar"],
+            root=root,
+        ),
+        "hpo": _resolve_hpo(
+            datasets["hpo"],
+            root=root,
+        ),
+        "pharmcat": _resolve_pharmcat(
+            datasets["pharmcat"],
+            root=root,
+        ),
+        "reference_genomes": _resolve_reference_genomes(
+            datasets.get("reference_genomes"),
+            root=root,
+        ),
+    }
+
+
+def _validate_user_reference(
+        fasta_path: Path,
+        *,
+        assembly: str,
+) -> dict[str, Any]:
+    fasta = fasta_path.expanduser().resolve()
+
+    if not fasta.exists():
+        raise ResourceManifestError(
+            f"Configured {assembly} reference genome "
+            f"does not exist: {fasta}"
+        )
+
+    if not fasta.is_file():
+        raise ResourceManifestError(
+            f"Configured {assembly} reference genome "
+            f"is not a file: {fasta}"
+        )
+
+    fai = Path(f"{fasta}.fai")
+
+    if not fai.exists():
+        raise ResourceManifestError(
+            f"FASTA index not found for configured {assembly} "
+            f"reference genome: {fai}. "
+            "Index the FASTA with 'samtools faidx' or provide "
+            "a reference installed by 'sftool resources setup'."
+        )
+
+    if not fai.is_file():
+        raise ResourceManifestError(
+            f"Configured {assembly} FASTA index "
+            f"is not a file: {fai}"
+        )
+
+    return {
+        "fasta": fasta,
+        "fai": fai.resolve(),
+        "source": "config",
+        "version": None,
+        "sha256": None,
+    }
+
+def _resolve_execution_reference(
+        *,
+        assembly: str,
+        configured_genomes: dict[str, Path | None],
+        installed_references: dict[
+            str,
+            dict[str, Any] | None
+        ],
+) -> dict[str, Any]:
+    configured_reference = configured_genomes.get(assembly)
+
+    if configured_reference is not None:
+        return _validate_user_reference(
+            configured_reference,
+            assembly=assembly,
+        )
+
+    installed_reference = installed_references.get(assembly)
+
+    if installed_reference is not None:
+        return {
+            "fasta": installed_reference["fasta"]["path"],
+            "fai": installed_reference["fai"]["path"],
+            "source": "manifest",
+            "version": installed_reference.get("version"),
+            "sha256": installed_reference["fasta"].get("sha256"),
+        }
+
+    raise ResourceManifestError(
+        f"No reference genome is available for {assembly}. "
+        f"Set references.genomes.{assembly} in the runtime "
+        "configuration or install reference genomes with "
+        "'sftool resources setup --download-reference-genomes'."
+    )
+
+def resolve_execution_resources(
+        *,
+        assembly: str,
+        clinvar_evidence: int,
+        categories: set[str],
+        configured_genomes: dict[str, Path | None],
+        installed: dict[str, Any],
+) -> dict[str, Any]:
+    if assembly not in SUPPORTED_ASSEMBLIES:
+        raise ResourceManifestError(
+            f"Unsupported assembly: {assembly}"
+        )
+
+    assembly_catalogs = (
+        installed["catalogs"]
+        ["assemblies"]
+        .get(assembly)
+    )
+
+    if assembly_catalogs is None:
+        raise ResourceManifestError(
+            f"No installed catalogs are available for {assembly}"
+        )
+
+    clinvar_assembly = (
+        installed["clinvar"]
+        ["assemblies"]
+        .get(assembly)
+    )
+
+    if clinvar_assembly is None:
+        raise ResourceManifestError(
+            f"No installed ClinVar resources are "
+            f"available for {assembly}"
+        )
+
+    selected_catalogs: dict[str, Any] = {}
+    selected_clinvar: dict[str, Any] = {}
+
+    for category in sorted(categories):
+        if category not in SUPPORTED_CATALOGS:
+            continue
+
+        catalog = assembly_catalogs.get(category)
+
+        if catalog is None:
+            raise ResourceManifestError(
+                f"No installed {category} catalog is "
+                f"available for {assembly}"
+            )
+
+        selected_catalogs[category] = catalog
+
+        evidence_files = (
+            clinvar_assembly["catalogs"]
+            .get(category, {})
+        )
+
+        clinvar_file = evidence_files.get(clinvar_evidence)
+
+        if clinvar_file is None:
+            raise ResourceManifestError(
+                f"No installed ClinVar resource is available "
+                f"for assembly={assembly}, "
+                f"catalog={category}, "
+                f"evidence={clinvar_evidence}"
+            )
+
+        selected_clinvar[category] = clinvar_file
+
+    return {
+        "reference_genome": _resolve_execution_reference(
+            assembly=assembly,
+            configured_genomes=configured_genomes,
+            installed_references=installed["reference_genomes"],
+        ),
+        "catalogs": selected_catalogs,
+        "clinvar": selected_clinvar,
+        "clinvar_database": clinvar_assembly["database"],
+        "rr_str": installed["catalogs"]["RR_STR"],
+        "hpo": installed["hpo"],
+        "pharmcat": installed["pharmcat"],
+    }
+
+def get_required_resource_categories(
+        samples_info: dict[str, Any],
+) -> set[str]:
+    execution = samples_info["execution"]
+
+    if "secondary_findings_discovery" not in execution["modes"]:
+        return set()
+
+    required = {
+        category
+        for sample in samples_info["samples"]
+        for category in sample.get("categories", [])
+        if category in {"PR", "RR"}
+    }
+
+    return required

--- a/sftool/core/resources.py
+++ b/sftool/core/resources.py
@@ -182,8 +182,8 @@ def _validate_manifest_structure(
 
     _validate_catalog_manifest(datasets["catalogs"])
     _validate_clinvar_manifest(datasets["clinvar"])
-    _validate_single_file_dataset("hpo", datasets["hpo"])
-    _validate_single_file_dataset("pharmcat", datasets["pharmcat"])
+    _validate_single_file_dataset("hpo", datasets.get("hpo"), descriptor_key="file")
+    _validate_single_file_dataset("pharmcat", datasets.get("pharmcat"), descriptor_key="positions_vcf")
     _validate_reference_manifest(
         datasets.get("reference_genomes")
     )
@@ -536,6 +536,8 @@ def _resolve_clinvar(
 def _validate_single_file_dataset(
         dataset_name: str,
         dataset: Any,
+        *,
+        descriptor_key: str,
 ) -> None:
     if not isinstance(dataset, dict):
         raise ResourceManifestError(
@@ -545,11 +547,6 @@ def _validate_single_file_dataset(
     _validate_version(
         dataset.get("version"),
         label=f"datasets.{dataset_name}.version",
-    )
-
-    descriptor_key = _find_single_descriptor_key(
-        dataset_name,
-        dataset,
     )
 
     _validate_file_descriptor(
@@ -564,13 +561,12 @@ def _resolve_hpo(
 ) -> dict[str, Any]:
     return {
         "version": hpo["version"],
-        "gene_to_phenotype": _resolve_descriptor(
-            hpo["gene_to_phenotype"],
+        "file": _resolve_descriptor(
+            hpo["file"],
             root=root,
-            label="datasets.hpo.gene_to_phenotype",
+            label="datasets.hpo.file",
         ),
     }
-
 
 def _resolve_pharmcat(
         pharmcat: dict[str, Any],
@@ -579,10 +575,10 @@ def _resolve_pharmcat(
 ) -> dict[str, Any]:
     return {
         "version": pharmcat["version"],
-        "positions": _resolve_descriptor(
-            pharmcat["positions"],
+        "positions_vcf": _resolve_descriptor(
+            pharmcat["positions_vcf"],
             root=root,
-            label="datasets.pharmcat.positions",
+            label="datasets.pharmcat.positions_vcf",
         ),
     }
 

--- a/sftool/utils/checksums.py
+++ b/sftool/utils/checksums.py
@@ -1,0 +1,70 @@
+# sftool/utils/checksums.py
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+class ChecksumError(RuntimeError):
+    """
+    Raised when a file checksum cannot be calculated.
+    """
+
+
+def calculate_sha256(
+        path: Path | str,
+        *,
+        chunk_size: int = 1024 * 1024,
+) -> str:
+    """
+    Calculate the lowercase SHA-256 digest of a file.
+
+    Args:
+        path:
+            File whose digest will be calculated.
+        chunk_size:
+            Number of bytes read per iteration.
+
+    Returns:
+        Lowercase hexadecimal SHA-256 digest.
+
+    Raises:
+        ValueError:
+            If chunk_size is not greater than zero.
+        ChecksumError:
+            If the path does not exist, is not a regular file,
+            or cannot be read.
+    """
+    file_path = Path(path)
+
+    if chunk_size <= 0:
+        raise ValueError(
+            "chunk_size must be greater than zero"
+        )
+
+    if not file_path.exists():
+        raise ChecksumError(
+            f"Cannot calculate SHA-256 because the file "
+            f"does not exist: {file_path}"
+        )
+
+    if not file_path.is_file():
+        raise ChecksumError(
+            f"Cannot calculate SHA-256 because the path "
+            f"is not a file: {file_path}"
+        )
+
+    digest = hashlib.sha256()
+
+    try:
+        with file_path.open("rb") as handle:
+            while chunk := handle.read(chunk_size):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ChecksumError(
+            f"Could not read file while calculating SHA-256: "
+            f"{file_path}"
+        ) from exc
+
+    return digest.hexdigest()

--- a/sftool/utils/errors.py
+++ b/sftool/utils/errors.py
@@ -50,3 +50,9 @@ class ModuleExecutionError(Exception):
     - logic errors occur inside the module
     """
     pass
+
+class ResourceManifestError(Exception):
+    """
+    Raised when installed resources cannot be loaded or resolved.
+    """
+    pass

--- a/sftool/utils/manifest_utils.py
+++ b/sftool/utils/manifest_utils.py
@@ -7,9 +7,12 @@ from typing import Any
 
 from sftool.utils.resource_utils import (
     ResourceOperationError,
-    calculate_sha256,
     read_json,
     write_json,
+)
+from sftool.utils.checksums import (
+    ChecksumError,
+    calculate_sha256,
 )
 
 
@@ -78,9 +81,17 @@ def describe_installed_file(
             f"Installed resource file does not exist: {absolute_path}"
         )
 
+    try:
+        checksum = calculate_sha256(absolute_path)
+    except ChecksumError as exc:
+        raise ResourceOperationError(
+            f"Could not calculate checksum for installed "
+            f"resource file: {absolute_path}"
+        ) from exc
+
     descriptor = {
         "path": relative_path.as_posix(),
-        "sha256": calculate_sha256(absolute_path),
+        "sha256": checksum,
     }
 
     if source_url is not None:

--- a/sftool/utils/resource_utils.py
+++ b/sftool/utils/resource_utils.py
@@ -10,9 +10,12 @@ from typing import Any
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
-import hashlib
 from collections.abc import Mapping, Callable
 import shutil
+from sftool.utils.checksums import (
+    ChecksumError,
+    calculate_sha256,
+)
 
 
 BUNDLED_RESOURCE_PACKAGE = "sftool.data.resources"
@@ -533,55 +536,6 @@ def download_file(
 
     return destination
 
-def calculate_sha256(
-        path: Path,
-        *,
-        chunk_size: int = 1024 * 1024,
-) -> str:
-    """
-    Calculate the SHA-256 digest of a file.
-
-    Parameters
-    ----------
-    path
-        File to hash.
-    chunk_size
-        Number of bytes read per iteration.
-
-    Returns
-    -------
-    str
-        Lowercase hexadecimal SHA-256 digest.
-
-    Raises
-    ------
-    ResourceOperationError
-        If the path does not exist, is not a file, or cannot be read.
-    """
-
-    file_path = Path(path)
-
-    if not file_path.is_file():
-        raise ResourceOperationError(
-            f"Cannot calculate checksum because the resource file "
-            f"does not exist: {file_path}"
-        )
-
-    if chunk_size <= 0:
-        raise ValueError("chunk_size must be greater than zero.")
-
-    digest = hashlib.sha256()
-
-    try:
-        with file_path.open("rb") as handle:
-            while chunk := handle.read(chunk_size):
-                digest.update(chunk)
-    except OSError as error:
-        raise ResourceOperationError(
-            f"Could not read resource file: {file_path}"
-        ) from error
-
-    return digest.hexdigest()
 
 def write_json(
         data: Mapping[str, Any],
@@ -710,11 +664,19 @@ def download_versioned_resource(
     if validator is not None:
         validator(path)
 
+    try:
+        checksum = calculate_sha256(path)
+    except ChecksumError as exc:
+        raise ResourceOperationError(
+            f"Could not calculate checksum for downloaded "
+            f"{resource_name} resource: {path}"
+        ) from exc
+
     return {
         "version": version,
         "source_url": specification["url"],
         "path": path.relative_to(output_root).as_posix(),
-        "sha256": calculate_sha256(path),
+        "sha256": checksum,
     }
 
 def validate_hpo_gene_to_phenotype(path: Path) -> None:


### PR DESCRIPTION
## Summary
This PR completes Phase 4 of issue #58  by integrating the installed resource manifest into the SFtool runtime bootstrap.

It adds runtime configuration for the manifest, validates the installed resource bundle and checksums before execution, and resolves the resources required for the selected assembly, categories, ClinVar evidence level, and reference genome.

The resolved catalog, ClinVar, HPO, PharmCAT, RR-STR, and reference genome resources are now exposed through the execution context, preparing sftool run for the remaining runtime-stage integration.

## Related Issue
Refs #58 

## Type of change
- [X] Feature (feat)
- [ ] Bug fix (fix)
- [X] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [X] Tests
- [ ] Maintenance / Chore

## Checklist
- [X] Code compiles and runs
- [X] Tests added or updated
- [ ] Documentation updated
- [X] Linked the related issue (e.g., "Refs #58 ")
